### PR TITLE
fix: overflow scroll to auto

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
   <div id="dataTable" class='lg:mt-2'></div>
 </div>
 <div class="col-span-12 order-6 md:order-none md:col-span-8 lg:col-span-9 xl:col-span-10 px-2" id="charts-container">
-  <div class="flex flex-wrap lg:flex-nowrap gap-2 overflow-scroll">
+  <div class="flex flex-wrap lg:flex-nowrap gap-2 overflow-x-auto max-w-full">
     <div id="xplot-div" class="my-2 w-11/12 mx-auto flex flex-col justify-center items-center rounded-md box-border border border-gray-300">
       <div id="xplot"></div>
       <div class='flex flex-row w-full justify-center mt-2 border-t-2 border-gray-100'>


### PR DESCRIPTION
`overflow-scroll` will always show a scroll bar even if there is no scrolling to be done.

`overflow-x-auto` will only show a scroll bar if scrolling can be done.

This change won’t do anything until https://github.com/xmrit/xmrit/pull/10 is merged though, as the css needs to be rebuilt.