### PR TITLE
Remove background image from charts

### DIFF
--- a/js/chart.ts
+++ b/js/chart.ts
@@ -7,29 +7,17 @@ import {
 } from "./util";
 
 const ECHARTS_DATE_FORMAT = "{d} {MMM}";
-const BACKGROUND_IMAGE_PATH = "../xmrit-bg.png";
 
 const toolbox = {
   feature: {
     saveAsImage: {
       type: "png",
       pixelRatio: 2,
-      backgroundColor: {
-        image: BACKGROUND_IMAGE_PATH,
-        scaleX: 1,
-        scaleY: 1,
-        repeat: "no-repeat",
-      },
     },
   },
 };
 
-const backgroundColor = {
-  image: BACKGROUND_IMAGE_PATH,
-  scaleX: 0.5,
-  scaleY: 0.5,
-  repeat: "no-repeat",
-};
+const backgroundColor = "#ffffff";
 
 const xAxis = {
   type: "time",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "start": "cp xmrit-bg.png dist/ && parcel index.html",
-    "build": "parcel build index.html && cp xmrit-bg.png dist/"
+    "start": "parcel index.html",
+    "build": "parcel build index.html"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.9",


### PR DESCRIPTION
## Summary
- Replaced the background image with a solid white background
- Removed image copying from build and start scripts
- Simplified chart configuration in chart.ts

## Test plan
- Verify charts render with a solid white background
- Confirm build and start scripts work correctly without the image copying step

🤖 Generated with [Claude Code](https://claude.ai/code)