### PR TITLE
Replace Handsontable with AG Grid Community (MIT licensed)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -54,9 +54,46 @@
   }
 }
 
-.handsontable .duplicate,
+.ag-theme-alpine .duplicate,
 #duplicate-data-warning {
   background-color: #fffced;
+}
+
+/* AG Grid context menu */
+.xmrit-context-menu {
+  position: fixed;
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+  z-index: 1000;
+  min-width: 160px;
+  padding: 4px 0;
+}
+
+.xmrit-context-menu-item {
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.xmrit-context-menu-item:hover {
+  background-color: #eff6ff;
+}
+
+.xmrit-context-menu-item.disabled {
+  color: #9ca3af;
+  cursor: default;
+}
+
+.xmrit-context-menu-item.disabled:hover {
+  background-color: transparent;
+}
+
+.xmrit-context-menu-separator {
+  height: 1px;
+  background-color: #e5e7eb;
+  margin: 4px 0;
 }
 
 .words {
@@ -87,7 +124,7 @@
   height: 100%;
   background-color: rgba(0, 0, 0, 0.5);
   display: none;
-  /* hot header z-index is 160 */
+  /* must sit above AG Grid's internal z-indices (max ~10 for headers) */
   z-index: 200;
 }
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <link rel="stylesheet" href="/css/styles.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/handsontable/dist/handsontable.full.min.css" />
+  <!-- AG Grid theme is applied via JS module import -->
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
 
   <link rel="icon" href="https://xmrit.com/favicon.ico">
@@ -219,7 +219,9 @@
                   <button class="p-1 text-blue-700 hover:bg-blue-100 rounded-md text-sm" id="deseason-reset-data"
                     type="button">Replace from table</button>
                 </div>
-                <div id="deseason-dataTable"></div>
+                <div id="deseason-dataTable" class="ag-theme-alpine"></div>
+                <button class="mt-1 px-2 py-1 text-xs text-blue-700 hover:bg-blue-100 rounded" id="extend-dates-deseason"
+                  type="button">+ Extend dates</button>
               </div>
 
 
@@ -230,7 +232,7 @@
                   <button class="p-1 text-blue-700 hover:bg-blue-100 rounded-md text-sm" id="deseason-reset-factors"
                     type="button">Recalculate seasonal factors</button>
                 </div>
-                <div id="seasonal-factors-dataTable"></div>
+                <div id="seasonal-factors-dataTable" class="ag-theme-alpine"></div>
               </div>
 
             </div>
@@ -297,7 +299,9 @@
             <button class="p-1 text-blue-700 hover:bg-blue-100 rounded-md text-sm" id="lock-limit-reset-data"
               type="button">Reset data (from table)</button>
           </div>
-          <div id="lock-limit-dataTable"></div>
+          <div id="lock-limit-dataTable" class="ag-theme-alpine"></div>
+          <button class="mt-1 px-2 py-1 text-xs text-blue-700 hover:bg-blue-100 rounded" id="extend-dates-locked"
+            type="button">+ Extend dates</button>
         </div>
         <div id="trend-backdrop" class="modal-backdrop"></div>
         <div id="trend-dialog" class="modal p-6 overflow-y-auto bg-white rounded-xl shadow-xl max-w-prose">
@@ -351,7 +355,9 @@
                 type="button">
                 Reset data (from table)</button>
             </div>
-            <div id="trend-dataTable"></div>
+            <div id="trend-dataTable" class="ag-theme-alpine"></div>
+            <button class="mt-1 px-2 py-1 text-xs text-blue-700 hover:bg-blue-100 rounded" id="extend-dates-trend"
+              type="button">+ Extend dates</button>
 
           </div>
         </div>
@@ -400,7 +406,9 @@
             table, results might be inaccurate.
         </p>
         </p>
-        <div id="dataTable" class='lg:mt-2'></div>
+        <div id="dataTable" class='lg:mt-2 ag-theme-alpine'></div>
+        <button class="mt-1 px-2 py-1 text-xs text-blue-700 hover:bg-blue-100 rounded" id="extend-dates-main"
+          type="button">+ Extend dates</button>
       </div>
       <div class="col-span-12 order-6 md:order-none md:col-span-8 lg:col-span-9 xl:col-span-10 px-2"
         id="charts-container">

--- a/js/ag-grid-wrapper.ts
+++ b/js/ag-grid-wrapper.ts
@@ -1,0 +1,394 @@
+/**
+ * AG Grid wrapper module for Xmrit
+ */
+import dayjs from "dayjs";
+import {
+  type GridApi,
+  type GridOptions,
+  type ColDef,
+  type CellValueChangedEvent,
+  type IHeaderComp,
+  type IHeaderParams,
+  createGrid,
+  ModuleRegistry,
+  AllCommunityModule,
+  themeAlpine,
+} from "ag-grid-community";
+
+// Register all community modules
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+const compactTheme = themeAlpine.withParams({
+  fontSize: 12,
+  spacing: 3,
+  headerFontSize: 12,
+});
+
+// ── Types ──
+
+export interface XmritGridConfig<T = any> {
+  element: HTMLElement;
+  data: T[];
+  columnDefs: ColDef<T>[];
+  colHeaders?: string[];
+  onCellValueChanged?: (event: CellValueChangedEvent<T>) => void;
+  minSpareRows?: boolean; // whether to keep a spare empty row at the bottom
+  dataSchema?: T;
+  /** If true, allow right-click row insert/remove */
+  contextMenu?: boolean;
+  /** If false, don't allow insert/remove rows from context menu */
+  allowInsertRow?: boolean;
+  /** If true, show row numbers */
+  rowHeaders?: boolean;
+}
+
+export interface XmritGrid<T = any> {
+  api: GridApi<T>;
+  updateSettings(opts: { data?: T[]; colHeaders?: string[] }): void;
+  updateData(data: T[]): void;
+  getColHeaders(): string[];
+  destroy(): void;
+}
+
+// ── Context Menu ──
+
+let activeContextMenu: HTMLElement | null = null;
+
+function removeContextMenu() {
+  if (activeContextMenu) {
+    activeContextMenu.remove();
+    activeContextMenu = null;
+  }
+  document.removeEventListener("click", removeContextMenu);
+}
+
+function showContextMenu<T>(
+  event: MouseEvent,
+  api: GridApi<T>,
+  rowIndex: number,
+  allowInsertRow: boolean,
+  dataSchema: T | undefined,
+  ensureSpareRowFn: (() => void) | null
+) {
+  removeContextMenu();
+  event.preventDefault();
+
+  const menu = document.createElement("div");
+  menu.className = "xmrit-context-menu";
+
+  type MenuItem = { label: string; action: () => void; disabled?: boolean } | "separator";
+  const items: MenuItem[] = [];
+
+  // Row operations
+  if (allowInsertRow) {
+    items.push({
+      label: "Insert row above",
+      action: () => {
+        const newRow = dataSchema
+          ? JSON.parse(JSON.stringify(dataSchema))
+          : ({} as any);
+        api.applyTransaction({ add: [newRow], addIndex: rowIndex });
+        ensureSpareRowFn?.();
+      },
+    });
+    items.push({
+      label: "Insert row below",
+      action: () => {
+        const newRow = dataSchema
+          ? JSON.parse(JSON.stringify(dataSchema))
+          : ({} as any);
+        api.applyTransaction({ add: [newRow], addIndex: rowIndex + 1 });
+        ensureSpareRowFn?.();
+      },
+    });
+  }
+
+  items.push({
+    label: "Remove row",
+    action: () => {
+      const rowNode = api.getDisplayedRowAtIndex(rowIndex);
+      if (rowNode) {
+        api.applyTransaction({ remove: [rowNode.data] });
+        ensureSpareRowFn?.();
+      }
+    },
+  });
+
+  items.push("separator");
+
+  // Undo / Redo
+  items.push({
+    label: "Undo",
+    action: () => { api.undoCellEditing(); },
+    disabled: api.getCurrentUndoSize() === 0,
+  });
+  items.push({
+    label: "Redo",
+    action: () => { api.redoCellEditing(); },
+    disabled: api.getCurrentRedoSize() === 0,
+  });
+
+
+  items.forEach((item) => {
+    if (item === "separator") {
+      const hr = document.createElement("div");
+      hr.className = "xmrit-context-menu-separator";
+      menu.appendChild(hr);
+      return;
+    }
+    const div = document.createElement("div");
+    div.className = "xmrit-context-menu-item";
+    if (item.disabled) div.classList.add("disabled");
+    div.textContent = item.label;
+    div.addEventListener("click", () => {
+      if (!item.disabled) item.action();
+      removeContextMenu();
+    });
+    menu.appendChild(div);
+  });
+
+  menu.style.left = `${event.clientX}px`;
+  menu.style.top = `${event.clientY}px`;
+  document.body.appendChild(menu);
+  activeContextMenu = menu;
+
+  // Close on next click anywhere
+  setTimeout(() => {
+    document.addEventListener("click", removeContextMenu);
+  }, 0);
+}
+
+// ── Clickable Header Component (for main table editable headers) ──
+
+export class ClickableHeader implements IHeaderComp {
+  private eGui!: HTMLElement;
+  private params!: IHeaderParams;
+
+  init(params: IHeaderParams): void {
+    this.params = params;
+    this.eGui = document.createElement("div");
+    this.eGui.className = "xmrit-clickable-header";
+    this.eGui.textContent = params.displayName;
+    this.eGui.style.cursor = "pointer";
+    this.eGui.style.width = "100%";
+    this.eGui.addEventListener("click", () => {
+      const onHeaderClick = (params as any).onHeaderClick;
+      if (onHeaderClick) {
+        onHeaderClick(params.column.getColId(), params.displayName);
+      }
+    });
+  }
+
+  getGui(): HTMLElement {
+    return this.eGui;
+  }
+
+  refresh(params: IHeaderParams): boolean {
+    this.params = params;
+    this.eGui.textContent = params.displayName;
+    return true;
+  }
+
+  destroy(): void {}
+}
+
+// ── Spare Row Helper ──
+
+function createEnsureSpareRows<T>(
+  api: GridApi<T>,
+  dataSchema: T | undefined,
+  enabled: boolean
+): (() => void) | null {
+  if (!enabled) return null;
+  return () => {
+    const rowCount = api.getDisplayedRowCount();
+    if (rowCount === 0) {
+      const newRow = dataSchema
+        ? JSON.parse(JSON.stringify(dataSchema))
+        : ({} as any);
+      api.applyTransaction({ add: [newRow] });
+      return;
+    }
+    const lastRow = api.getDisplayedRowAtIndex(rowCount - 1);
+    if (!lastRow) return;
+    const data = lastRow.data as any;
+    // Check if last row has any non-null/non-empty values
+    const hasData = Object.values(data).some(
+      (v) => v !== null && v !== undefined && v !== ""
+    );
+    if (hasData) {
+      const newRow = dataSchema
+        ? JSON.parse(JSON.stringify(dataSchema))
+        : ({} as any);
+      api.applyTransaction({ add: [newRow] });
+    }
+  };
+}
+
+// ── Factory ──
+
+export function createXmritGrid<T>(config: XmritGridConfig<T>): XmritGrid<T> {
+  const {
+    element,
+    data,
+    columnDefs,
+    colHeaders,
+    onCellValueChanged,
+    minSpareRows = false,
+    dataSchema,
+    contextMenu = true,
+    allowInsertRow = true,
+    rowHeaders = false,
+  } = config;
+
+  let currentColHeaders = colHeaders ? [...colHeaders] : [];
+
+  // Build column defs with headers
+  const buildColDefs = (headers: string[]): ColDef<T>[] => {
+    return columnDefs.map((col, i) => ({
+      ...col,
+      headerName: headers[i] ?? col.headerName ?? (col as any).field ?? "",
+    }));
+  };
+
+  // Add row number column if needed
+  const finalColDefs = rowHeaders
+    ? [
+        {
+          headerName: "#",
+          valueGetter: "node.rowIndex + 1",
+          width: 50,
+          editable: false,
+          sortable: false,
+          suppressMovable: true,
+        } as ColDef<T>,
+        ...buildColDefs(currentColHeaders),
+      ]
+    : buildColDefs(currentColHeaders);
+
+  const gridOptions: GridOptions<T> = {
+    theme: compactTheme,
+    columnDefs: finalColDefs,
+    rowData: [...data],
+    defaultColDef: {
+      flex: 1,
+      editable: true,
+      sortable: false,
+      filter: false,
+      suppressMovable: true,
+    },
+    domLayout: "autoHeight",
+    undoRedoCellEditing: true,
+    preventDefaultOnContextMenu: true,
+    singleClickEdit: true,
+    stopEditingWhenCellsLoseFocus: true,
+    suppressDragLeaveHidesColumns: true,
+    rowDragManaged: false,
+    getRowId: undefined, // use index-based identity
+    onCellValueChanged: (event) => {
+      ensureSpareRowFn?.();
+      onCellValueChanged?.(event);
+    },
+    onCellContextMenu: (event) => {
+      if (contextMenu && event.event) {
+        showContextMenu(
+          event.event as MouseEvent,
+          api,
+          event.rowIndex!,
+          allowInsertRow,
+          dataSchema,
+          ensureSpareRowFn
+        );
+      }
+    },
+  };
+
+  const api = createGrid(element, gridOptions);
+  const ensureSpareRowFn = createEnsureSpareRows(api, dataSchema, minSpareRows);
+
+  // Ensure initial spare row
+  ensureSpareRowFn?.();
+
+  const grid: XmritGrid<T> = {
+    api,
+    updateSettings(opts) {
+      if (opts.colHeaders) {
+        currentColHeaders = [...opts.colHeaders];
+      }
+      if (opts.data !== undefined) {
+        api.setGridOption("rowData", [...opts.data]);
+      }
+      // Always update column defs when headers change
+      if (opts.colHeaders) {
+        const newDefs = rowHeaders
+          ? [
+              {
+                headerName: "#",
+                valueGetter: "node.rowIndex + 1",
+                width: 50,
+                editable: false,
+                sortable: false,
+                suppressMovable: true,
+              } as ColDef<T>,
+              ...buildColDefs(currentColHeaders),
+            ]
+          : buildColDefs(currentColHeaders);
+        api.setGridOption("columnDefs", newDefs);
+      }
+      ensureSpareRowFn?.();
+    },
+    updateData(newData) {
+      api.setGridOption("rowData", [...newData]);
+      ensureSpareRowFn?.();
+    },
+    getColHeaders() {
+      return [...currentColHeaders];
+    },
+    destroy() {
+      api.destroy();
+    },
+  };
+
+  return grid;
+}
+
+// ── Date Extension Helper (for "Extend dates" button) ──
+
+/**
+ * Detects date pattern from existing dates and generates new dates.
+ * Uses dayjs for consistent timezone handling with the rest of the app.
+ */
+export function extendDateSeries(
+  dates: string[],
+  count: number
+): string[] {
+  const validDates = dates.filter((d) => d);
+  if (validDates.length === 0) return [];
+
+  const dateObjs = validDates.map((d) => dayjs(d, "YYYY-MM-DD"));
+
+  // Detect interval in days between consecutive dates
+  let diffDays = 1; // default: one day
+  if (dateObjs.length >= 2) {
+    diffDays = dateObjs[1].diff(dateObjs[0], "day");
+    // Verify consistent pattern
+    for (let i = 2; i < dateObjs.length; i++) {
+      if (dateObjs[i].diff(dateObjs[i - 1], "day") !== diffDays) {
+        // Inconsistent pattern, fall back to diff between last two
+        diffDays = dateObjs[dateObjs.length - 1].diff(
+          dateObjs[dateObjs.length - 2],
+          "day"
+        );
+        break;
+      }
+    }
+  }
+
+  const result: string[] = [];
+  let last = dateObjs[dateObjs.length - 1];
+  for (let i = 0; i < count; i++) {
+    last = last.add(diffDays, "day");
+    result.push(last.format("YYYY-MM-DD"));
+  }
+  return result;
+}

--- a/js/main3.ts
+++ b/js/main3.ts
@@ -1,15 +1,22 @@
 import chroma from "chroma-js";
 import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
 import duration from "dayjs/plugin/duration";
 import quarterOfYear from "dayjs/plugin/quarterOfYear";
 // Seasonality
+dayjs.extend(customParseFormat);
 dayjs.extend(duration);
 dayjs.extend(quarterOfYear);
 
 import { init as initEChart } from "echarts";
 import type { EChartsType } from "echarts";
-import Handsontable from "handsontable";
-import { CellMeta } from "handsontable/settings";
+import type { ColDef } from "ag-grid-community";
+import {
+  createXmritGrid,
+  extendDateSeries,
+  ClickableHeader,
+  type XmritGrid,
+} from "./ag-grid-wrapper";
 
 import lz77 from "./lz77";
 
@@ -164,9 +171,8 @@ const DUMMY_DATA: DataValue[] = INITIAL_VALUES.map(function (el, i) {
 
 // This is the state of the app.
 const state = {
-  // tableData, xLabel and yLabel is set by the handsontable (the table rendered onscreen).
-  // for handsontable to be reactive, use hot.updateSettings({ ... }). Don't just use assignment.
-  tableData: [] as DataValue[], // handsontable data. Might contain null values.
+  // tableData, xLabel and yLabel is set by the grid (the table rendered onscreen).
+  tableData: [] as DataValue[], // grid data. Might contain null values.
   lockedLimitBaseData: [] as DataValue[], // data for the locked limit lines
   xLabel: "Date",
   yLabel: "Value",
@@ -1396,11 +1402,11 @@ screen.orientation.addEventListener("change", (e) => {
   redraw("changeOrientation");
 });
 
-let hot: Handsontable;
-let lockedLimitHot: Handsontable;
-let deseasonaliseHot: Handsontable;
-let seasonalFactorsHot: Handsontable;
-let trendHot: Handsontable;
+let grid: XmritGrid;
+let lockedLimitGrid: XmritGrid;
+let deseasonaliseGrid: XmritGrid;
+let seasonalFactorsGrid: XmritGrid;
+let trendGrid: XmritGrid;
 
 let dTableColors = [];
 
@@ -1424,74 +1430,33 @@ function updateDTableSeasonalFactorMapping() {
     }
   });
 
-  if (deseasonaliseHot) {
-    deseasonaliseHot.updateData(state.seasonalFactorData);
+  if (deseasonaliseGrid) {
+    deseasonaliseGrid.updateData(state.seasonalFactorData);
   }
 }
 
-const _seasonalDataCellRenderer = (
-  instance,
-  td,
-  row,
-  col,
-  prop,
-  value,
-  cellProperties
-) => {
-  // This renders the text
-  Handsontable.renderers.TextRenderer(
-    instance,
-    td,
-    row,
-    col,
-    prop,
-    value,
-    cellProperties
-  );
-
+// AG Grid cellStyle callbacks for seasonal coloring
+const seasonalDataCellStyle = (params: any) => {
+  const row = params.node.rowIndex;
   if (
     row < state.seasonalFactorData.length - 1 &&
     state.seasonalFactorData[row]
   ) {
     const sfIndex = state.seasonalFactorData[row].seasonalFactor - 1;
-    td.style.background = dTableColors[sfIndex] ?? "salmon";
-    td.style.borderBottomColor = dTableColors[sfIndex];
+    return { background: dTableColors[sfIndex] ?? "salmon", 
+             borderBottomColor: dTableColors[sfIndex]};
   }
+  return {};
 };
 
-const _seasonalFactorCellRenderer = (
-  instance,
-  td,
-  row,
-  col,
-  prop,
-  value,
-  cellProperties
-) => {
-  // This renders the text
-  Handsontable.renderers.TextRenderer(
-    instance,
-    td,
-    row,
-    col,
-    prop,
-    value,
-    cellProperties
-  );
-
-  td.style.background = dTableColors[row];
-  td.style.borderBottomColor = dTableColors[row];
+const seasonalFactorCellStyle = (params: any) => {
+  const row = params.node.rowIndex;
+  const bg = dTableColors[row];
+  if (bg) {
+    return { background: bg, borderBottomColor: bg };
+  }
+  return {};
 };
-
-// maps function to a lookup string
-Handsontable.renderers.registerRenderer(
-  "seasonalDataRenderer",
-  _seasonalDataCellRenderer
-);
-Handsontable.renderers.registerRenderer(
-  "seasonalFactorRenderer",
-  _seasonalFactorCellRenderer
-);
 
 function lockLimits() {
   const lockedLimits = calculateLockedLimits(); // calculate locked limits from the table
@@ -1530,7 +1495,60 @@ function lockLimits() {
   redraw("addLockLimit");
 }
 
-function initialiseHandsOnTable() {
+function dateValueSetter(params: any): boolean {
+  const val = params.newValue;
+  if (!val || val === "") {
+    params.data.x = null;
+    return true;
+  }
+  const d = dayjs(val, "YYYY-MM-DD", true);
+  if (!d.isValid()) {
+    const errorMsg = document.getElementById("data-table-error");
+    errorMsg?.classList.remove("hidden");
+    return false;
+  }
+  document.getElementById("data-table-error")?.classList.add("hidden");
+  params.data.x = val;
+  return true;
+}
+
+function numericValueParser(params: any) {
+  if (params.newValue === null || params.newValue === undefined || params.newValue === "") {
+    return null;
+  }
+  const val = parseFloat(String(params.newValue).replace(/[^0-9.\-]/g, ""));
+  return isNaN(val) ? null : val;
+}
+
+function makeDateCol(): ColDef {
+  return {
+    field: "x",
+    valueSetter: dateValueSetter,
+    cellEditor: "agTextCellEditor",
+  };
+}
+
+function makeValueCol(): ColDef {
+  return {
+    field: "value",
+    valueParser: numericValueParser,
+  };
+}
+
+// Duplicate tracking set for main table
+let duplicateRows = new Set<number>();
+
+/** Sync all row data from an AG Grid instance back to a state array.
+ *  Returns the synced array (same reference if possible, new array if rows were added/removed). */
+function syncGridToState<T>(grid: XmritGrid, currentState: T[]): T[] {
+  const rowData: T[] = [];
+  grid.api.forEachNode((node) => {
+    if (node.data) rowData.push(node.data);
+  });
+  return rowData;
+}
+
+function initialiseGrids() {
   const seasonalFactorsDataTable = document.querySelector(
     "#seasonal-factors-dataTable"
   ) as HTMLDivElement;
@@ -1545,354 +1563,208 @@ function initialiseHandsOnTable() {
   ) as HTMLDivElement;
   const table = document.querySelector("#dataTable") as HTMLDivElement;
 
-  trendHot = trendDataTable ? new Handsontable(trendDataTable, {
-    licenseKey: "non-commercial-and-evaluation", // for non-commercial use only
-    data: state.trendData,
-    dataSchema: { x: null, value: null },
-    columns: [
-      {
-        data: "x",
-        type: "date",
-        dateFormat: "YYYY-MM-DD",
-        validator: (value, callback) => {
-          if (!value) {
-            // if null, "", or undefined
-            callback(true);
-            return;
-          }
-
-          let d = new Date(fromDateStr(value));
-          // https://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript#1353711
-          // callback(true) if date != 'Invalid Date'
-          callback(d instanceof Date && !isNaN(d.getTime()));
-        },
+  // ── Trend table ──
+  if (trendDataTable) {
+    trendGrid = createXmritGrid({
+      element: trendDataTable,
+      data: state.trendData,
+      dataSchema: { x: null, value: null } as any,
+      columnDefs: [makeDateCol(), makeValueCol()],
+      colHeaders: [state.xLabel, state.yLabel],
+      contextMenu: true,
+      minSpareRows: true,
+      onCellValueChanged: (_event) => {
+        state.trendData = syncGridToState(trendGrid, state.trendData);
+        calculateTrendStats();
       },
-      { data: "value", type: "numeric" },
-    ],
-    colHeaders: [state.xLabel, state.yLabel],
-    // Show context menu to enable removing rows.
-    contextMenu: true,
-    allowRemoveColumn: false,
-    minSpareRows: 1,
-    height: "auto",
-    stretchH: "all",
-    fillHandle: {
-      autoInsertRow: true,
-      direction: "vertical",
-    },
-    beforeAutofill(selectionData, sourceRange, targetRange, direction) {
-      return autofillTable(selectionData, sourceRange, targetRange, direction);
-    },
-    beforePaste(data, coords) {
-      return beforePasteTable(data, coords);
-    },
-    afterChange(changes, source) {
-      if (source === "loadData") {
-        return;
-      }
-      calculateTrendStats();
-    },
-    afterValidate(isValid, value, row, prop, source) {
-      const errorMsg = document.getElementById("data-table-error");
-      if (isValid) {
-        errorMsg.classList.add("hidden");
-        return;
-      }
-      errorMsg.classList.remove("hidden");
-      return false;
-    },
-  }) : undefined;
+    });
+  }
 
-  seasonalFactorsHot = seasonalFactorsDataTable ? new Handsontable(seasonalFactorsDataTable, {
-    colHeaders: ["Seasonal Factors"],
-    data: state.seasonalFactorTableData,
-    rowHeaders: true,
-    // colHeaders: sfCols,
-    // Show context menu to enable removing rows.
-    contextMenu: true,
-    allowRemoveColumn: false,
-    height: "auto",
-    stretchH: "all",
-    allowInsertRow: false,
-    allowInsertColumn: false,
-    beforeAutofill(selectionData, sourceRange, targetRange, direction) {
-      return autofillTable(selectionData, sourceRange, targetRange, direction);
-    },
-    beforePaste(data, coords) {
-      return beforePasteTable(data, coords);
-    },
-    afterChange(changes, source) {
-      if (source === "edit" && state.isShowingDeseasonalisedData) {
-        redraw("updateDeseasonalisedData");
-      }
-    },
-    afterValidate(isValid, value, row, prop, source) {
-      const errorMsg = document.getElementById("data-table-error");
-      if (isValid) {
-        errorMsg.classList.add("hidden");
-        return;
-      }
-      errorMsg.classList.remove("hidden");
-      return false;
-    },
-    // the `cells` options overwrite all other options
-    cells(row, col, prop) {
-      const cellProperties: CellMeta = {
-        renderer: "seasonalFactorRenderer",
-      };
-      if (row === 0) {
-        cellProperties.type = "numeric";
-      }
-      return cellProperties;
-    },
-    licenseKey: "non-commercial-and-evaluation", // for non-commercial use only
-  }) : undefined;
-
-  deseasonaliseHot = deseasonaliseDataTable ? new Handsontable(deseasonaliseDataTable, {
-    data: state.seasonalFactorData,
-    dataSchema: { x: null, value: null },
-    columns: [
-      {
-        data: "x",
-        type: "date",
-        dateFormat: "YYYY-MM-DD",
-        validator: (value, callback) => {
-          if (!value) {
-            // if null, "", or undefined
-            callback(true);
-            return;
-          }
-
-          let d = new Date(fromDateStr(value));
-          // https://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript#1353711
-          // callback(true) if date != 'Invalid Date'
-          callback(d instanceof Date && !isNaN(d.getTime()));
+  // ── Seasonal Factors table ──
+  if (seasonalFactorsDataTable) {
+    seasonalFactorsGrid = createXmritGrid({
+      element: seasonalFactorsDataTable,
+      data: state.seasonalFactorTableData,
+      columnDefs: [
+        {
+          headerName: "value",
+          valueGetter: (params: any) => params.data?.[0],
+          valueSetter: (params: any) => {
+            params.data[0] = parseFloat(params.newValue) || null;
+            return true;
+          },
+          cellStyle: seasonalFactorCellStyle,
         },
+      ],
+      colHeaders: ["Seasonal Factors"],
+      contextMenu: true,
+      allowInsertRow: false,
+      rowHeaders: true,
+      minSpareRows: false,
+      onCellValueChanged: (_event) => {
+        state.seasonalFactorTableData = syncGridToState(seasonalFactorsGrid, state.seasonalFactorTableData);
+        if (state.isShowingDeseasonalisedData) {
+          redraw("updateDeseasonalisedData");
+        }
       },
-      { data: "value", type: "numeric" },
-      { data: "seasonalFactor", type: "numeric" },
-    ],
-    colHeaders: [state.xLabel, state.yLabel, "Season"],
-    // Show context menu to enable removing rows.
-    contextMenu: true,
-    allowRemoveColumn: false,
-    minSpareRows: 1,
-    height: "auto",
-    stretchH: "all",
-    fillHandle: {
-      autoInsertRow: true,
-      direction: "vertical",
-    },
-    beforeAutofill(selectionData, sourceRange, targetRange, direction) {
-      return autofillTable(selectionData, sourceRange, targetRange, direction);
-    },
-    afterChange(changes, source) {
-      // Check range of values entered
-      // get range of data in deseason table
-      const data = sortDataValues(
-        state.seasonalFactorData.filter((d) => d.x != null)
-      );
-      const startDate = dayjs(data[0].x);
-      const endDate = dayjs(data[data.length - 1].x);
+    });
+  }
 
-      // Get selected period
-      const selectedPeriod = (document.querySelector("#period-select") as HTMLSelectElement).value;
+  // ── Deseasonalise table ──
+  if (deseasonaliseDataTable) {
+    deseasonaliseGrid = createXmritGrid({
+      element: deseasonaliseDataTable,
+      data: state.seasonalFactorData,
+      dataSchema: { x: null, value: null } as any,
+      columnDefs: [
+        { ...makeDateCol(), cellStyle: seasonalDataCellStyle },
+        { ...makeValueCol(), cellStyle: seasonalDataCellStyle },
+        {
+          field: "seasonalFactor",
+          valueParser: numericValueParser,
+          cellStyle: seasonalDataCellStyle,
+        },
+      ],
+      colHeaders: [state.xLabel, state.yLabel, "Season"],
+      // Show context menu to enable removing rows.
+      contextMenu: true,
+      minSpareRows: true,
+      onCellValueChanged: (_event) => {
+        state.seasonalFactorData = syncGridToState(deseasonaliseGrid, state.seasonalFactorData);
+        // Check range of values entered
+        // get range of data in deseason table
+        const data = sortDataValues(
+          state.seasonalFactorData.filter((d) => d.x != null)
+        );
+        if (data.length < 2) return;
+        const startDate = dayjs(data[0].x);
+        const endDate = dayjs(data[data.length - 1].x);
 
+        // Get selected period
+        const selectedPeriod = (document.querySelector("#period-select") as HTMLSelectElement).value;
+        
       // Calculate difference based on selected period
-      const periodDiff = Math.abs(startDate.diff(endDate, selectedPeriod as any, true));
+        const periodDiff = Math.abs(startDate.diff(endDate, selectedPeriod as any, true));
 
-      // Show warning if less than one period
-      if (periodDiff < 1) {
-        showElement(document.querySelector("#deseason-warn-1"));
-      } else {
-        hideElement(document.querySelector("#deseason-warn-1"));
-      }
+        // Show warning if less than one period
+        if (periodDiff < 1) {
+          showElement(document.querySelector("#deseason-warn-1"));
+        } else {
+          hideElement(document.querySelector("#deseason-warn-1"));
+        }
 
       // Show warning if exactly one period
-      if (periodDiff === 1) {
-        showElement(document.querySelector("#deseason-warn-2"));
-      } else {
-        hideElement(document.querySelector("#deseason-warn-2"));
-      }
+        if (periodDiff === 1) {
+          showElement(document.querySelector("#deseason-warn-2"));
+        } else {
+          hideElement(document.querySelector("#deseason-warn-2"));
+        }
 
-      if (source === "edit") {
         updateSeasonalFactors();
-      }
-    },
-    afterValidate(isValid, value, row, prop, source) {
-      const errorMsg = document.getElementById("data-table-error");
-      if (isValid) {
-        errorMsg.classList.add("hidden");
-        return;
-      }
-      errorMsg.classList.remove("hidden");
-      return false;
-    },
-    cells(row, col) {
-      const cellProperties: CellMeta = {};
-
-      cellProperties.renderer = "seasonalDataRenderer"; // uses lookup map
-
-      return cellProperties;
-    },
-    licenseKey: "non-commercial-and-evaluation", // for non-commercial use only
-  }) : undefined;
-
-  lockedLimitHot = lockedLimitDataTable ? new Handsontable(lockedLimitDataTable, {
-    data: state.lockedLimitBaseData,
-    dataSchema: { x: null, value: null },
-    columns: [
-      {
-        data: "x",
-        type: "date",
-        dateFormat: "YYYY-MM-DD",
-        validator: (value, callback) => {
-          if (!value) {
-            // if null, "", or undefined
-            callback(true);
-            return;
-          }
-
-          let d = new Date(fromDateStr(value));
-          // https://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript#1353711
-          // callback(true) if date != 'Invalid Date'
-          callback(d instanceof Date && !isNaN(d.getTime()));
-        },
       },
-      { data: "value", type: "numeric" },
-    ],
-    colHeaders: [state.xLabel, state.yLabel],
-    // Show context menu to enable removing rows.
-    contextMenu: true,
-    allowRemoveColumn: false,
-    minSpareRows: 1,
-    height: "auto",
-    stretchH: "all",
-    fillHandle: {
-      autoInsertRow: true,
-      direction: "vertical",
-    },
-    beforeAutofill(selectionData, sourceRange, targetRange, direction) {
-      return autofillTable(selectionData, sourceRange, targetRange, direction);
-    },
-    beforePaste(data, coords) {
-      return beforePasteTable(data, coords);
-    },
-    afterChange(changes, source) {
-      if (source === "loadData") {
-        return;
-      }
-      setLockedLimitInputs(true);
-    },
-    afterValidate(isValid, value, row, prop, source) {
-      const errorMsg = document.getElementById("data-table-error");
-      if (isValid) {
-        errorMsg.classList.add("hidden");
-        return;
-      }
-      errorMsg.classList.remove("hidden");
-      return false;
-    },
-    licenseKey: "non-commercial-and-evaluation", // for non-commercial use only
-  }) : undefined;
+    });
+  }
 
-  hot = new Handsontable(table, {
+  // ── Locked Limit table ──
+  if (lockedLimitDataTable) {
+    lockedLimitGrid = createXmritGrid({
+      element: lockedLimitDataTable,
+      data: state.lockedLimitBaseData,
+      dataSchema: { x: null, value: null } as any,
+      columnDefs: [makeDateCol(), makeValueCol()],
+      colHeaders: [state.xLabel, state.yLabel],
+      // Show context menu to enable removing rows.
+      contextMenu: true,
+      minSpareRows: true,
+      onCellValueChanged: (_event) => {
+        state.lockedLimitBaseData = syncGridToState(lockedLimitGrid, state.lockedLimitBaseData);
+        setLockedLimitInputs(true);
+      },
+    });
+  }
+
+  // ── Main data table ──
+  const onHeaderClick = (colId: string, displayName: string) => {
+    const newColName = prompt("Insert a new column name", displayName);
+    if (newColName) {
+      const headers = grid.getColHeaders();
+      const colIndex = colId === "x" ? 0 : 1;
+      headers[colIndex] = newColName;
+      grid.updateSettings({ colHeaders: headers });
+      if (colIndex === 0) {
+        state.xLabel = newColName;
+      } else {
+        state.yLabel = newColName;
+      }
+      redraw("editColumnName");
+    }
+  };
+
+  grid = createXmritGrid({
+    element: table,
     data: state.tableData,
-    dataSchema: { x: null, value: null },
-    columns: [
+    dataSchema: { x: null, value: null } as any,
+    columnDefs: [
       {
-        data: "x",
-        type: "date",
-        dateFormat: "YYYY-MM-DD",
-        validator: (value, callback) => {
-          if (!value) {
-            // if null, "", or undefined
-            callback(true);
-            return;
-          }
-
-          let d = new Date(fromDateStr(value));
-          // https://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript#1353711
-          // callback(true) if date != 'Invalid Date'
-          callback(d instanceof Date && !isNaN(d.getTime()));
+        ...makeDateCol(),
+        headerComponent: ClickableHeader,
+        headerComponentParams: { onHeaderClick },
+        cellClassRules: {
+          duplicate: (params: any) => duplicateRows.has(params.node.rowIndex),
         },
       },
-      { data: "value", type: "numeric" },
+      {
+        ...makeValueCol(),
+        headerComponent: ClickableHeader,
+        headerComponentParams: { onHeaderClick },
+      },
     ],
     colHeaders: [
       state.xLabel ?? "Date",
       state.yLabel === "Value" ? "Value (✏️)" : state.yLabel,
     ],
-    // Editable column header: https://github.com/handsontable/handsontable/issues/1980
-    afterOnCellMouseDown: function (e, coords) {
-      if (coords.row !== -1) {
-        return;
-      }
-      let newColName = prompt(
-        "Insert a new column name",
-        this.getColHeader()[coords.col]
-      );
-      if (newColName) {
-        let colHeaders = this.getColHeader();
-        colHeaders[coords.col] = newColName;
-        this.updateSettings({
-          colHeaders,
-        });
-        if (coords.col == 0) {
-          state.xLabel = newColName;
-        } else {
-          state.yLabel = newColName;
-        }
-        // Redraw
-        redraw("editColumnName");
-      }
-    },
     // Show context menu to enable removing rows.
     contextMenu: true,
-    allowRemoveColumn: false,
-    minSpareRows: 1,
-    height: "auto",
-    stretchH: "all",
-    fillHandle: {
-      autoInsertRow: true,
-      direction: "vertical",
-    },
-    beforeAutofill(selectionData, sourceRange, targetRange, direction) {
-      return autofillTable(selectionData, sourceRange, targetRange, direction);
-    },
-    beforePaste(data, coords) {
-      return beforePasteTable(data, coords);
-    },
-    beforeChange(changes, source) {
-      let xOnly = state.xdata.map((d) => d.x);
-      changes.forEach(([row, prop, oldVal, newVal], idx) => {
-        if (prop == "x") {
-          xOnly[row] = newVal;
-        }
-        if (prop == "value") {
-          // force float by removing special characters
-          changes[idx][3] = forceFloat(newVal);
-        }
-      });
-      checkDuplicatesInTable(xOnly, this);
-    },
-    afterChange(changes, source) {
-      if (source == "loadData") {
-        return;
-      }
+    minSpareRows: true,
+    onCellValueChanged: (event) => {
+      // Sync grid → state (captures new rows from spare row)
+      state.tableData = syncGridToState(grid, state.tableData);
+      // Check for duplicates after any change
+      const allData: string[] = state.tableData.map((d) => d.x ?? null);
+      checkDuplicatesInTable(allData);
       redraw("editTableData");
     },
-    afterValidate(isValid, value, row, prop, source) {
-      const errorMsg = document.getElementById("data-table-error");
-      if (isValid) {
-        errorMsg.classList.add("hidden");
-        return;
-      }
-      errorMsg.classList.remove("hidden");
-      return false;
-    },
-    licenseKey: "non-commercial-and-evaluation", // for non-commercial use only
   });
+
+  // ── "Extend dates" button handlers ──
+  document.getElementById("extend-dates-main")?.addEventListener("click", () => {
+    handleExtendDates(grid, "tableData");
+  });
+  document.getElementById("extend-dates-trend")?.addEventListener("click", () => {
+    handleExtendDates(trendGrid, "trendData");
+  });
+  document.getElementById("extend-dates-deseason")?.addEventListener("click", () => {
+    handleExtendDates(deseasonaliseGrid, "seasonalFactorData");
+  });
+  document.getElementById("extend-dates-locked")?.addEventListener("click", () => {
+    handleExtendDates(lockedLimitGrid, "lockedLimitBaseData");
+  });
+}
+
+function handleExtendDates(grid: XmritGrid, stateKey: "tableData" | "trendData" | "seasonalFactorData" | "lockedLimitBaseData") {
+  if (!grid) return;
+  const data = state[stateKey] as any[];
+  const dates = data.filter((d: any) => d.x).map((d: any) => d.x);
+  if (dates.length === 0) return;
+  const countStr = prompt("How many rows to add?", "5");
+  if (!countStr) return;
+  const count = parseInt(countStr, 10);
+  if (isNaN(count) || count <= 0) return;
+  const newDates = extendDateSeries(dates, count);
+  const newRows = newDates.map((d) => ({ x: d, value: null }));
+  grid.api.applyTransaction({ add: newRows });
+  // Sync back to state
+  (state as any)[stateKey] = syncGridToState(grid, data);
 }
 
 // LOGIC ON PAGE LOAD
@@ -2290,7 +2162,7 @@ document.addEventListener("DOMContentLoaded", async function (_e) {
   });
 
   // Data table
-  initialiseHandsOnTable();
+  initialiseGrids();
 
   // CSV data management
   const csvFile = document.getElementById("csv-file") as HTMLInputElement;
@@ -2340,7 +2212,7 @@ document.addEventListener("DOMContentLoaded", async function (_e) {
       state.yLabel = yLabel;
       state.tableData = xdata;
       state.lockedLimitBaseData = deepClone(state.tableData);
-      hot.updateSettings({
+      grid.updateSettings({
         data: xdata,
         colHeaders: [xLabel, yLabel],
       });
@@ -2562,121 +2434,17 @@ function setLockedLimitInputs(updateInputValue: boolean) {
   ).placeholder = `${lv.URL}`;
 }
 
-// An implementation of excel drag-to-extend-series for handsontable
-function autofillTable(selectionData, sourceRange, targetRange, direction) {
-  if (sourceRange.from.col == 1) {
-    // use default behaviour if its the data column
-    // if targetRange is larger than source range, the selected data will be repeated.
-    return selectionData;
-  }
-
-  // most likely, the user is trying to extend the current pattern.
-  // if there is a pattern, we will try to extend the pattern
-  // otherwise we will just use default behaviour.
-  let dateArray = selectionData.map((x) => new Date(fromDateStr(x[0])));
-  let difference = 86400000; // one day
-  if (dateArray.length >= 2) {
-    difference = dateArray[1].valueOf() - dateArray[0].valueOf();
-    for (let i = 2; i < dateArray.length; i++) {
-      if (dateArray[i].valueOf() - dateArray[i - 1].valueOf() != difference) {
-        // pattern is broken
-        return selectionData;
-      }
-    }
-  }
-
-  let result = [];
-  // If only one row is selected, we increment by one day only
-  if (dateArray.length < 2) {
-    if (direction == "down") {
-      result = dateArray.map(
-        (x) => new Date(new Date(x.valueOf()).setDate(x.getDate() + 1))
-      );
-      for (
-        let i = result.length;
-        i <= targetRange.to.row - targetRange.from.row;
-        i++
-      ) {
-        let cd = result[result.length - 1];
-        result.push(new Date(new Date(cd.valueOf()).setDate(cd.getDate() + 1)));
-      }
-    } else if (direction == "up") {
-      result = dateArray.map(
-        (x) => new Date(new Date(x.valueOf()).setDate(x.getDate() - 1))
-      );
-      for (
-        let i = result.length;
-        i <= targetRange.to.row - targetRange.from.row;
-        i++
-      ) {
-        let cd = result[0];
-        // much more expensive than downwards extension, but user should rarely hit this...
-        result = [
-          new Date(new Date(cd.valueOf()).setDate(cd.getDate() - 1)),
-          ...result,
-        ];
-      }
-    }
-    return result.map((x) => [toDateStr(x)]);
-  }
-
-  // If more than one row was selected we increment by computed difference
-  // Note that this doesn't handle daylight savings time, so two days out of
-  // every year this will give wrong results.
-  if (direction == "down") {
-    result = dateArray.map(
-      (x) => new Date(x.valueOf() + dateArray.length * difference)
-    );
-    for (
-      let i = result.length;
-      i <= targetRange.to.row - targetRange.from.row;
-      i++
-    ) {
-      result.push(new Date(result[result.length - 1].valueOf() + difference));
-    }
-  } else if (direction == "up") {
-    result = dateArray.map(
-      (x) => new Date(x.valueOf() - dateArray.length * difference)
-    );
-    for (
-      let i = result.length;
-      i <= targetRange.to.row - targetRange.from.row;
-      i++
-    ) {
-      // much more expensive than downwards extension, but user should rarely hit this...
-      result = [new Date(result[0].valueOf() - difference), ...result];
-    }
-  }
-  return result.map((x) => [toDateStr(x)]);
-}
-
-// Modifying paste behaviour
-function beforePasteTable(data, coords) {
-  if (coords.length > 1) return;
-  let coord = coords[0];
-  // if selected area has more rows than the data, we add empty '' to the end of data to simulate clearing this rows
-  // This change handles the common edge case where user copy, say from other sources, and paste a smaller set of data
-  // than the one currently exists in the table.
-  // The default behaviour of the CopyPaste plugin is to repeat the data until the end of the selected area,
-  // which causes wrong calculation (and crossing lines in the chart) due to repeated data at the end.
-  for (let i = coord.startRow + data.length; i <= coord.endRow; i++) {
-    // endRow is inclusive.
-    data.push(["", ""]);
-  }
-  return;
-}
 
 // Check duplicate in the x value (first column) of the table and set background color accordingly
-function checkDuplicatesInTable(arr: string[], tableInstance) {
-  let seen = {};
+function checkDuplicatesInTable(arr: string[]) {
+  let seen: Record<string, boolean> = {};
   let isDuplicateDetected = false;
+  duplicateRows = new Set<number>();
   arr.forEach((el, idx) => {
     if (!el) return; // null or ""
     if (el in seen) {
-      tableInstance.setCellMeta(idx, 0, "className", "duplicate");
+      duplicateRows.add(idx);
       isDuplicateDetected = true;
-    } else {
-      tableInstance.setCellMeta(idx, 0, "className", "");
     }
     seen[el] = true;
   });
@@ -2684,9 +2452,14 @@ function checkDuplicatesInTable(arr: string[], tableInstance) {
   if (isDuplicateDetected) {
     document
       .getElementById("duplicate-data-warning")
-      .classList.remove("hidden");
+      ?.classList.remove("hidden");
   } else {
-    document.getElementById("duplicate-data-warning").classList.add("hidden");
+    document.getElementById("duplicate-data-warning")?.classList.add("hidden");
+  }
+
+  // Refresh the date column to update cell class rules
+  if (grid?.api) {
+    grid.api.refreshCells({ force: true, columns: ["x"] });
   }
 }
 
@@ -2974,10 +2747,10 @@ function renderChartGraphics(stats: _Stats) {
 function promptNewColumnName() {
   let newColName = prompt("Insert a new column name", state.yLabel);
   if (newColName) {
-    let colHeaders = hot.getColHeader();
+    let colHeaders = grid.getColHeaders();
     colHeaders[1] = newColName;
     state.yLabel = newColName;
-    hot.updateSettings({
+    grid.updateSettings({
       colHeaders,
     });
     redraw("editChartTitle");
@@ -3003,8 +2776,8 @@ function updateSeasonalFactors() {
     hideElement(document.querySelector("#deseason-warn-3"));
   }
 
-  if (seasonalFactorsHot != null) {
-    seasonalFactorsHot.updateData(state.seasonalFactorTableData);
+  if (seasonalFactorsGrid != null) {
+    seasonalFactorsGrid.updateData(state.seasonalFactorTableData);
     updateDTableSeasonalFactorMapping();
   }
 }
@@ -3025,7 +2798,7 @@ function updateDeseasonalisedData() {
 
 function resetDeseasonalisedDialogTable() {
   state.seasonalFactorData = deepClone(state.tableData);
-  deseasonaliseHot.updateSettings({
+  deseasonaliseGrid.updateSettings({
     data: state.seasonalFactorData,
   });
   updateDTableSeasonalFactorMapping();
@@ -3035,7 +2808,7 @@ function resetDeseasonalisedDialogTable() {
 function resetLockedLimitDialogTable() {
   // let the locked limit data reflect the latest x data if locked limits are not currently active
   updateInPlace(state.lockedLimitBaseData, state.xdata);
-  lockedLimitHot.updateSettings({
+  lockedLimitGrid.updateSettings({
     data: state.lockedLimitBaseData,
     colHeaders: [state.xLabel, state.yLabel],
   });
@@ -3043,7 +2816,7 @@ function resetLockedLimitDialogTable() {
 
 function resetTrendDialogTable() {
   state.trendData = deepClone(state.tableData);
-  trendHot.updateData(state.trendData);
+  trendGrid.updateData(state.trendData);
   state.trendLines = createTrendlines(state.regressionStats, state.trendData);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "xmrit",
       "dependencies": {
+        "ag-grid-community": "^35.1.0",
+        "chroma-js": "^3.2.0",
         "dayjs": "^1.11.10",
         "echarts": "^5.5.1",
-        "handsontable": "^14.3.0",
         "typescript": "^5.4.5"
       },
       "devDependencies": {
@@ -31,110 +31,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.24.2",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
-      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@handsontable/pikaday": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@handsontable/pikaday/-/pikaday-1.0.0.tgz",
-      "integrity": "sha512-1VN6N38t5/DcjJ7y7XUYrDx1LuzvvzlrFdBdMG90Qo1xc8+LXHqbWbsTEm5Ec5gXTEbDEO53vUT35R+2COmOyg=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -202,16 +98,18 @@
       }
     },
     "node_modules/@lezer/common": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.1.tgz",
-      "integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==",
-      "dev": true
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@lezer/lr": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.0.tgz",
-      "integrity": "sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -224,6 +122,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -237,6 +136,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -250,6 +150,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -263,6 +164,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -276,6 +178,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -289,6 +192,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -299,6 +203,7 @@
       "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.1.tgz",
       "integrity": "sha512-iA7+tyVqfrATAIsIRWQG+a7ZLLD0VaOCKV2Wd/v4mqIU3J9c4jx9p7S0nw1XH3gJCKNBOOwACOPYYSUu9pgT+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0",
         "@lezer/lr": "^1.0.0",
@@ -309,78 +214,84 @@
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
-      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
-      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
-      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
-      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
-      "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
-      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -422,21 +333,22 @@
       }
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.12.0.tgz",
-      "integrity": "sha512-3ybN74oYNMKyjD6V20c9Gerdbh7teeNvVMwIoHIQMzuIFT6IGX53PyOLlOKRLbjxMc0TMimQQxIt2eQqxR5LsA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.16.4.tgz",
+      "integrity": "sha512-Nb8peNvhfm1+660CLwssWh4weY+Mv6vEGS6GPKqzJmTMw50udi0eS1YuWFzvmhSiu1KsYcUD37mqQ1LuIDtWoA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/graph": "3.2.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/utils": "2.12.0",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/graph": "3.6.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -444,37 +356,39 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
-      "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.16.4.tgz",
+      "integrity": "sha512-+uCyeElSga2MBbmbXpIj/WVKH7TByCrKaxtHbelfKKIJpYMgEHVjO4cuc7GUfTrUAmRUS8ZGvnX7Etgq6/jQhw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/fs": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/utils": "2.12.0",
+        "@parcel/fs": "2.16.4",
+        "@parcel/logger": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "lmdb": "2.8.5"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.12.0"
+        "@parcel/core": "^2.16.4"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
-      "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.4.tgz",
+      "integrity": "sha512-s64aMfOJoPrXhKH+Y98ahX0O8aXWvTR+uNlOaX4yFkpr4FFDnviLcGngDe/Yo4Qq2FJZ0P6dNswbJTUH9EGxkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "chalk": "^4.1.0"
+        "chalk": "^4.1.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -482,16 +396,17 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.12.0.tgz",
-      "integrity": "sha512-h41Q3X7ZAQ9wbQ2csP8QGrwepasLZdXiuEdpUryDce6rF9ZiHoJ97MRpdLxOhOPyASTw/xDgE1xyaPQr0Q3f5A==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.16.4.tgz",
+      "integrity": "sha512-IK8IpNhw61B2HKgA1JhGhO9y+ZJFRZNTEmvhN1NdLdPqvgEXm2EunT+m6D9z7xeoeT6XnUKqM0eRckEdD0OXbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0"
+        "@parcel/plugin": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -499,85 +414,88 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.12.0.tgz",
-      "integrity": "sha512-dPNe2n9eEsKRc1soWIY0yToMUPirPIa2QhxcCB3Z5RjpDGIXm0pds+BaiqY6uGLEEzsjhRO0ujd4v2Rmm0vuFg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.16.4.tgz",
+      "integrity": "sha512-kBxuTY/5trEVnvXk92l7LVkYjNuz3SaqWymFhPjEnc8GY4ZVdcWrWdXWTB9hUhpmRYJctFCyGvM0nN05JTiM2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/bundler-default": "2.12.0",
-        "@parcel/compressor-raw": "2.12.0",
-        "@parcel/namer-default": "2.12.0",
-        "@parcel/optimizer-css": "2.12.0",
-        "@parcel/optimizer-htmlnano": "2.12.0",
-        "@parcel/optimizer-image": "2.12.0",
-        "@parcel/optimizer-svgo": "2.12.0",
-        "@parcel/optimizer-swc": "2.12.0",
-        "@parcel/packager-css": "2.12.0",
-        "@parcel/packager-html": "2.12.0",
-        "@parcel/packager-js": "2.12.0",
-        "@parcel/packager-raw": "2.12.0",
-        "@parcel/packager-svg": "2.12.0",
-        "@parcel/packager-wasm": "2.12.0",
-        "@parcel/reporter-dev-server": "2.12.0",
-        "@parcel/resolver-default": "2.12.0",
-        "@parcel/runtime-browser-hmr": "2.12.0",
-        "@parcel/runtime-js": "2.12.0",
-        "@parcel/runtime-react-refresh": "2.12.0",
-        "@parcel/runtime-service-worker": "2.12.0",
-        "@parcel/transformer-babel": "2.12.0",
-        "@parcel/transformer-css": "2.12.0",
-        "@parcel/transformer-html": "2.12.0",
-        "@parcel/transformer-image": "2.12.0",
-        "@parcel/transformer-js": "2.12.0",
-        "@parcel/transformer-json": "2.12.0",
-        "@parcel/transformer-postcss": "2.12.0",
-        "@parcel/transformer-posthtml": "2.12.0",
-        "@parcel/transformer-raw": "2.12.0",
-        "@parcel/transformer-react-refresh-wrap": "2.12.0",
-        "@parcel/transformer-svg": "2.12.0"
+        "@parcel/bundler-default": "2.16.4",
+        "@parcel/compressor-raw": "2.16.4",
+        "@parcel/namer-default": "2.16.4",
+        "@parcel/optimizer-css": "2.16.4",
+        "@parcel/optimizer-html": "2.16.4",
+        "@parcel/optimizer-image": "2.16.4",
+        "@parcel/optimizer-svg": "2.16.4",
+        "@parcel/optimizer-swc": "2.16.4",
+        "@parcel/packager-css": "2.16.4",
+        "@parcel/packager-html": "2.16.4",
+        "@parcel/packager-js": "2.16.4",
+        "@parcel/packager-raw": "2.16.4",
+        "@parcel/packager-svg": "2.16.4",
+        "@parcel/packager-wasm": "2.16.4",
+        "@parcel/reporter-dev-server": "2.16.4",
+        "@parcel/resolver-default": "2.16.4",
+        "@parcel/runtime-browser-hmr": "2.16.4",
+        "@parcel/runtime-js": "2.16.4",
+        "@parcel/runtime-rsc": "2.16.4",
+        "@parcel/runtime-service-worker": "2.16.4",
+        "@parcel/transformer-babel": "2.16.4",
+        "@parcel/transformer-css": "2.16.4",
+        "@parcel/transformer-html": "2.16.4",
+        "@parcel/transformer-image": "2.16.4",
+        "@parcel/transformer-js": "2.16.4",
+        "@parcel/transformer-json": "2.16.4",
+        "@parcel/transformer-node": "2.16.4",
+        "@parcel/transformer-postcss": "2.16.4",
+        "@parcel/transformer-posthtml": "2.16.4",
+        "@parcel/transformer-raw": "2.16.4",
+        "@parcel/transformer-react-refresh-wrap": "2.16.4",
+        "@parcel/transformer-svg": "2.16.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.12.0"
+        "@parcel/core": "^2.16.4"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
-      "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.16.4.tgz",
+      "integrity": "sha512-a0CgrW5A5kwuSu5J1RFRoMQaMs9yagvfH2jJMYVw56+/7NRI4KOtu612SG9Y1ERWfY55ZwzyFxtLWvD6LO+Anw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/graph": "3.2.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/package-manager": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/profiler": "2.12.0",
-        "@parcel/rust": "2.12.0",
+        "@mischnic/json-sourcemap": "^0.1.1",
+        "@parcel/cache": "2.16.4",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/events": "2.16.4",
+        "@parcel/feature-flags": "2.16.4",
+        "@parcel/fs": "2.16.4",
+        "@parcel/graph": "3.6.4",
+        "@parcel/logger": "2.16.4",
+        "@parcel/package-manager": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/profiler": "2.16.4",
+        "@parcel/rust": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0",
-        "abortcontroller-polyfill": "^1.1.9",
-        "base-x": "^3.0.8",
-        "browserslist": "^4.6.6",
-        "clone": "^2.1.1",
-        "dotenv": "^7.0.0",
-        "dotenv-expand": "^5.1.0",
-        "json5": "^2.2.0",
-        "msgpackr": "^1.9.9",
+        "@parcel/types": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "@parcel/workers": "2.16.4",
+        "base-x": "^3.0.11",
+        "browserslist": "^4.24.5",
+        "clone": "^2.1.2",
+        "dotenv": "^16.5.0",
+        "dotenv-expand": "^11.0.7",
+        "json5": "^2.2.3",
+        "msgpackr": "^1.11.2",
         "nullthrows": "^1.1.1",
-        "semver": "^7.5.2"
+        "semver": "^7.7.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -585,16 +503,31 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
-      "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.4.tgz",
+      "integrity": "sha512-YN5CfX7lFd6yRLxyZT4Sj3sR6t7nnve4TdXSIqapXzQwL7Bw+sj79D95wTq2rCm3mzk5SofGxFAXul2/nG6gcQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
+        "@mischnic/json-sourcemap": "^0.1.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/error-overlay": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/error-overlay/-/error-overlay-2.16.4.tgz",
+      "integrity": "sha512-e8KYKnMsfmQnqIhsUWBUZAXlDK30wkxsAGle1tZ0gOdoplaIdVq/WjGPatHLf6igLM76c3tRn2vw8jZFput0jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -602,12 +535,27 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
-      "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.4.tgz",
+      "integrity": "sha512-slWQkBRAA7o0cN0BLEd+yCckPmlVRVhBZn5Pn6ktm4EzEtrqoMzMeJOxxH8TXaRzrQDYnTcnYIHFgXWd4kkUfg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/feature-flags": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.16.4.tgz",
+      "integrity": "sha512-nYdx53siKPLYikHHxfzgjzzgxdrjquK6DMnuSgOTyIdRG4VHdEN0+NqKijRLuVgiUFo/dtxc2h+amwqFENMw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -615,38 +563,42 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
-      "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.16.4.tgz",
+      "integrity": "sha512-maCMOiVn7oJYZlqlfxgLne8n6tSktIT1k0AeyBp4UGWCXyeJUJ+nL7QYShFpKNLtMLeF0cEtgwRAknWzbcDS1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/rust": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
+        "@parcel/feature-flags": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/types-internal": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.12.0"
+        "@parcel/workers": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.12.0"
+        "@parcel/core": "^2.16.4"
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
-      "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.6.4.tgz",
+      "integrity": "sha512-Cj9yV+/k88kFhE+D+gz0YuNRpvNOCVDskO9pFqkcQhGbsGq6kg2XpZ9V7HlYraih31xf8Vb589bZOwjKIiHixQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "@parcel/feature-flags": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -654,16 +606,17 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
-      "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.4.tgz",
+      "integrity": "sha512-QR8QLlKo7xAy9JBpPDAh0RvluaixqPCeyY7Fvo2K7hrU3r85vBNNi06pHiPbWoDmB4x1+QoFwMaGnJOHR+/fMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0"
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/events": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -671,15 +624,16 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
-      "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.4.tgz",
+      "integrity": "sha512-0+oQApAVF3wMcQ6d1ZfZ0JsRzaMUYj9e4U+naj6YEsFsFGOPp+pQYKXBf1bobQeeB7cPKPT3SUHxFqced722Hw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "chalk": "^4.1.0"
+        "chalk": "^4.1.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -687,18 +641,19 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.12.0.tgz",
-      "integrity": "sha512-9DNKPDHWgMnMtqqZIMiEj/R9PNWW16lpnlHjwK3ciRlMPgjPJ8+UNc255teZODhX0T17GOzPdGbU/O/xbxVPzA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.16.4.tgz",
+      "integrity": "sha512-CE+0lFg881sJq575EXxj2lKUn81tsS5itpNUUErHxit195m3PExyAhoXM6ed/SXxwi+uv+T5FS/jjDLBNuUFDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -706,21 +661,22 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
-      "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.7.4.tgz",
+      "integrity": "sha512-b3VDG+um6IWW5CTod6M9hQsTX5mdIelKmam7mzxzgqg4j5hnycgTWqPMc9UxhYoUY/Q/PHfWepccNcKtvP5JiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/utils": "2.12.0",
+        "@mischnic/json-sourcemap": "^0.1.1",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/fs": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "nullthrows": "^1.1.1",
-        "semver": "^7.5.2"
+        "semver": "^7.7.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -728,245 +684,111 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.12.0.tgz",
-      "integrity": "sha512-ifbcC97fRzpruTjaa8axIFeX4MjjSIlQfem3EJug3L2AVqQUXnM1XO8L0NaXGNLTW2qnh1ZjIJ7vXT/QhsphsA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.16.4.tgz",
+      "integrity": "sha512-aqdXCtmvpcXYgJFGk2DtXF34wuM2TD1fZorKMrJdKB9sSkWVRs1tq6RAXQrbi0ZPDH9wfE/9An3YdkTex7RHuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.12.0",
-        "browserslist": "^4.6.6",
-        "lightningcss": "^1.22.1",
+        "@parcel/utils": "2.16.4",
+        "browserslist": "^4.24.5",
+        "lightningcss": "^1.30.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.12.0.tgz",
-      "integrity": "sha512-MfPMeCrT8FYiOrpFHVR+NcZQlXAptK2r4nGJjfT+ndPBhEEZp4yyL7n1y7HfX9geg5altc4WTb4Gug7rCoW8VQ==",
+    "node_modules/@parcel/optimizer-html": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-html/-/optimizer-html-2.16.4.tgz",
+      "integrity": "sha512-vg/R2uuSni+NYYUUV8m+5bz8p5zBv8wc/nNleoBnGuCDwn7uaUwTZ8Gt9CjZO8jjG0xCLILoc/TW+e2FF3pfgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "htmlnano": "^2.0.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5",
-        "svgo": "^2.4.0"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/optimizer-htmlnano/node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/@parcel/optimizer-htmlnano/node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "dev": true,
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@parcel/optimizer-htmlnano/node_modules/csso": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
-      "dev": true,
-      "dependencies": {
-        "css-tree": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@parcel/optimizer-htmlnano/node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "dev": true
-    },
-    "node_modules/@parcel/optimizer-htmlnano/node_modules/svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
-      "dev": true,
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^4.1.3",
-        "css-tree": "^1.1.3",
-        "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "stable": "^0.1.8"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.12.0.tgz",
-      "integrity": "sha512-bo1O7raeAIbRU5nmNVtx8divLW9Xqn0c57GVNGeAK4mygnQoqHqRZ0mR9uboh64pxv6ijXZHPhKvU9HEpjPjBQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.16.4.tgz",
+      "integrity": "sha512-2RV54WnvMYr18lxSx7Zlx/DXpJwMzOiPxDnoFyvaUoYutvgHO6chtcgFgh1Bvw/PoI95vYzlTkZ8QfUOk5A0JA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0"
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "@parcel/workers": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.12.0"
+        "@parcel/core": "^2.16.4"
       }
     },
-    "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.12.0.tgz",
-      "integrity": "sha512-Kyli+ZZXnoonnbeRQdoWwee9Bk2jm/49xvnfb+2OO8NN0d41lblBoRhOyFiScRnJrw7eVl1Xrz7NTkXCIO7XFQ==",
+    "node_modules/@parcel/optimizer-svg": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svg/-/optimizer-svg-2.16.4.tgz",
+      "integrity": "sha512-22+BqIffCrVErg8y2XwhasbTaFNn75OKXZ3KTDBIfOSAZKLUKs1iHfDXETzTRN7cVcS+Q36/6EHd7N/RA8i1fg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "svgo": "^2.4.0"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/optimizer-svgo/node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/@parcel/optimizer-svgo/node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "dev": true,
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@parcel/optimizer-svgo/node_modules/csso": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
-      "dev": true,
-      "dependencies": {
-        "css-tree": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@parcel/optimizer-svgo/node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "dev": true
-    },
-    "node_modules/@parcel/optimizer-svgo/node_modules/svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
-      "dev": true,
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^4.1.3",
-        "css-tree": "^1.1.3",
-        "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "stable": "^0.1.8"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@parcel/optimizer-swc": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.12.0.tgz",
-      "integrity": "sha512-iBi6LZB3lm6WmbXfzi8J3DCVPmn4FN2lw7DGXxUXu7MouDPVWfTsM6U/5TkSHJRNRogZ2gqy5q9g34NPxHbJcw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.16.4.tgz",
+      "integrity": "sha512-+URqwnB6u1gqaLbG1O1DDApH+UVj4WCbK9No1fdxLBxQ9a84jyli25o1kK1hYB9Nb/JMyYNnEBfvYUW6RphOxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.12.0",
-        "@swc/core": "^1.3.36",
+        "@parcel/utils": "2.16.4",
+        "@swc/core": "^1.11.24",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -974,48 +796,50 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
-      "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.16.4.tgz",
+      "integrity": "sha512-obWv9gZgdnkT3Kd+fBkKjhdNEY7zfOP5gVaox5i4nQstVCaVnDlMv5FwLEXwehL+WbwEcGyEGGxOHHkAFKk7Cg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/node-resolver-core": "3.3.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0",
-        "@swc/core": "^1.3.36",
-        "semver": "^7.5.2"
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/fs": "2.16.4",
+        "@parcel/logger": "2.16.4",
+        "@parcel/node-resolver-core": "3.7.4",
+        "@parcel/types": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "@parcel/workers": "2.16.4",
+        "@swc/core": "^1.11.24",
+        "semver": "^7.7.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.12.0"
+        "@parcel/core": "^2.16.4"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.12.0.tgz",
-      "integrity": "sha512-j3a/ODciaNKD19IYdWJT+TP+tnhhn5koBGBWWtrKSu0UxWpnezIGZetit3eE+Y9+NTePalMkvpIlit2eDhvfJA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.16.4.tgz",
+      "integrity": "sha512-rWRtfiX+VVIOZvq64jpeNUKkvWAbnokfHQsk/js1s5jD4ViNQgPcNLiRaiIANjymqL6+dQqWvGUSW2a5FAZYfg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.12.0",
-        "lightningcss": "^1.22.1",
+        "@parcel/utils": "2.16.4",
+        "lightningcss": "^1.30.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1023,20 +847,20 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.12.0.tgz",
-      "integrity": "sha512-PpvGB9hFFe+19NXGz2ApvPrkA9GwEqaDAninT+3pJD57OVBaxB8U+HN4a5LICKxjUppPPqmrLb6YPbD65IX4RA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.16.4.tgz",
+      "integrity": "sha512-AWo5f6SSqBsg2uWOsX0gPX8hCx2iE6GYLg2Z4/cDy2mPlwDICN8/bxItEztSZFmObi+ti26eetBKRDxAUivyIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/types": "2.16.4",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1044,23 +868,24 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.12.0.tgz",
-      "integrity": "sha512-viMF+FszITRRr8+2iJyk+4ruGiL27Y6AF7hQ3xbJfzqnmbOhGFtLTQwuwhOLqN/mWR2VKdgbLpZSarWaO3yAMg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.16.4.tgz",
+      "integrity": "sha512-L2o39f/fhta+hxto7w8OTUKdstY+te5BmHZREckbQm0KTBg93BG7jB0bfoxLSZF0d8uuAYIVXjzeHNqha+du1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "globals": "^13.2.0",
+        "@parcel/types": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "globals": "^13.24.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1068,16 +893,17 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.12.0.tgz",
-      "integrity": "sha512-tJZqFbHqP24aq1F+OojFbQIc09P/u8HAW5xfndCrFnXpW4wTgM3p03P0xfw3gnNq+TtxHJ8c3UFE5LnXNNKhYA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.16.4.tgz",
+      "integrity": "sha512-A9j60G9OmbTkEeE4WRMXCiErEprHLs9NkUlC4HXCxmSrPMOVaMaMva2LdejE3A9kujZqYtYfuc8+a+jN+Nro4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0"
+        "@parcel/plugin": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1085,19 +911,20 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.12.0.tgz",
-      "integrity": "sha512-ldaGiacGb2lLqcXas97k8JiZRbAnNREmcvoY2W2dvW4loVuDT9B9fU777mbV6zODpcgcHWsLL3lYbJ5Lt3y9cg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.16.4.tgz",
+      "integrity": "sha512-LT9l7eInFrAZJ6w3mYzAUgDq3SIzYbbQyW46Dz26M9lJQbf6uCaATUTac3BEHegW0ikDuw4OOGHK41BVqeeusg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "posthtml": "^0.16.4"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/types": "2.16.4",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1105,16 +932,17 @@
       }
     },
     "node_modules/@parcel/packager-wasm": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.12.0.tgz",
-      "integrity": "sha512-fYqZzIqO9fGYveeImzF8ll6KRo2LrOXfD+2Y5U3BiX/wp9wv17dz50QLDQm9hmTcKGWxK4yWqKQh+Evp/fae7A==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.16.4.tgz",
+      "integrity": "sha512-AY96Aqu/RpmaSZK2RGkIrZWjAperDw8DAlxLAiaP1D/RPVnikZtl5BmcUt/Wz3PrzG7/q9ZVqqKkWsLmhkjXZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0"
+        "@parcel/plugin": "2.16.4"
       },
       "engines": {
-        "node": ">=12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">=16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1122,15 +950,16 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
-      "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.4.tgz",
+      "integrity": "sha512-aN2VQoRGC1eB41ZCDbPR/Sp0yKOxe31oemzPx1nJzOuebK2Q6FxSrJ9Bjj9j/YCaLzDtPwelsuLOazzVpXJ6qg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/types": "2.12.0"
+        "@parcel/types": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1138,17 +967,19 @@
       }
     },
     "node_modules/@parcel/profiler": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
-      "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.16.4.tgz",
+      "integrity": "sha512-R3JhfcnoReTv2sVFHPR2xKZvs3d3IRrBl9sWmAftbIJFwT4rU70/W7IdwfaJVkD/6PzHq9mcgOh1WKL4KAxPdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/events": "2.16.4",
+        "@parcel/types-internal": "2.16.4",
         "chrome-trace-event": "^1.0.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1156,20 +987,21 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.12.0.tgz",
-      "integrity": "sha512-TqKsH4GVOLPSCanZ6tcTPj+rdVHERnt5y4bwTM82cajM21bCX1Ruwp8xOKU+03091oV2pv5ieB18pJyRF7IpIw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.16.4.tgz",
+      "integrity": "sha512-DQx9TwcTZrDv828+tcwEi//xyW7OHTGzGX1+UEVxPp0mSzuOmDn0zfER8qNIqGr1i4D/FXhb5UJQDhGHV8mOpQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "chalk": "^4.1.0",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/types": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "chalk": "^4.1.2",
         "term-size": "^2.2.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1177,17 +1009,20 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.12.0.tgz",
-      "integrity": "sha512-tIcDqRvAPAttRlTV28dHcbWT5K2r/MBFks7nM4nrEDHWtnrCwimkDmZTc1kD8QOCCjGVwRHcQybpHvxfwol6GA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.16.4.tgz",
+      "integrity": "sha512-YWvay25htQDifpDRJ0+yFh6xUxKnbfeJxYkPYyuXdxpEUhq4T0UWW0PbPCN/wFX7StgeUTXq5Poeo/+eys9m3w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0"
+        "@parcel/codeframe": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1195,19 +1030,20 @@
       }
     },
     "node_modules/@parcel/reporter-tracer": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.12.0.tgz",
-      "integrity": "sha512-g8rlu9GxB8Ut/F8WGx4zidIPQ4pcYFjU9bZO+fyRIPrSUFH2bKijCnbZcr4ntqzDGx74hwD6cCG4DBoleq2UlQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.16.4.tgz",
+      "integrity": "sha512-JKnlXpPepak0/ZybmZn9JtyjJiDBWYrt7ZUlXQhQb0xzNcd/k+RqfwVkTKIwyFHsWtym0cwibkvsi2bWFzS7tw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1215,17 +1051,18 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.12.0.tgz",
-      "integrity": "sha512-uuhbajTax37TwCxu7V98JtRLiT6hzE4VYSu5B7Qkauy14/WFt2dz6GOUXPgVsED569/hkxebPx3KCMtZW6cHHA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.16.4.tgz",
+      "integrity": "sha512-wJe9XQS0hn/t32pntQpJbls3ZL8mGVVhK9L7s7BTmZT9ufnvP2nif1psJz/nbgnP9LF6mLSk43OdMJKpoStsjQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/node-resolver-core": "3.3.0",
-        "@parcel/plugin": "2.12.0"
+        "@parcel/node-resolver-core": "3.7.4",
+        "@parcel/plugin": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1233,17 +1070,18 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.12.0.tgz",
-      "integrity": "sha512-4ZLp2FWyD32r0GlTulO3+jxgsA3oO1P1b5oO2IWuWilfhcJH5LTiazpL5YdusUjtNn9PGN6QLAWfxmzRIfM+Ow==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.16.4.tgz",
+      "integrity": "sha512-asx7p3NjUSfibI3bC7+8+jUIGHWVk2Zuq9SjJGCGDt+auT9A4uSGljnsk1BWWPqqZ0WILubq4czSAqm0+wt4cw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1251,39 +1089,41 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.12.0.tgz",
-      "integrity": "sha512-sBerP32Z1crX5PfLNGDSXSdqzlllM++GVnVQVeM7DgMKS8JIFG3VLi28YkX+dYYGtPypm01JoIHCkvwiZEcQJg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.16.4.tgz",
+      "integrity": "sha512-gUKmsjg+PULQBu2QbX0QKll9tXSqHPO8NrfxHwWb2lz5xDKDos1oV0I7BoMWbHhUHkoToXZrm654oGViujtVUA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.12.0.tgz",
-      "integrity": "sha512-SCHkcczJIDFTFdLTzrHTkQ0aTrX3xH6jrA4UsCBL6ji61+w+ohy4jEEe9qCgJVXhnJfGLE43HNXek+0MStX+Mw==",
+    "node_modules/@parcel/runtime-rsc": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-rsc/-/runtime-rsc-2.16.4.tgz",
+      "integrity": "sha512-CHkotYE/cNiUjJmrc5FD9YhlFp1UF5wMNNJmoWaL40eBzsqcaV0sSn5V3bNapwewn3wrMYgdPgvOTHfaZaG73A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "react-error-overlay": "6.0.9",
-        "react-refresh": "^0.9.0"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1291,18 +1131,19 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.12.0.tgz",
-      "integrity": "sha512-BXuMBsfiwpIEnssn+jqfC3jkgbS8oxeo3C7xhSQsuSv+AF2FwY3O3AO1c1RBskEW3XrBLNINOJujroNw80VTKA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.16.4.tgz",
+      "integrity": "sha512-FT0Q58bf5Re+dq5cL2XHbxqHHFZco6qtRijeVpT3TSPMRPlniMArypSytTeZzVNL7h/hxjWsNu7fRuC0yLB5hA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1310,12 +1151,199 @@
       }
     },
     "node_modules/@parcel/rust": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
-      "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.4.tgz",
+      "integrity": "sha512-RBMKt9rCdv6jr4vXG6LmHtxzO5TuhQvXo1kSoSIF7fURRZ81D1jzBtLxwLmfxCPsofJNqWwdhy5vIvisX+TLlQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/rust-darwin-arm64": "2.16.4",
+        "@parcel/rust-darwin-x64": "2.16.4",
+        "@parcel/rust-linux-arm-gnueabihf": "2.16.4",
+        "@parcel/rust-linux-arm64-gnu": "2.16.4",
+        "@parcel/rust-linux-arm64-musl": "2.16.4",
+        "@parcel/rust-linux-x64-gnu": "2.16.4",
+        "@parcel/rust-linux-x64-musl": "2.16.4",
+        "@parcel/rust-win32-x64-msvc": "2.16.4"
+      },
+      "peerDependencies": {
+        "napi-wasm": "^1.1.2"
+      },
+      "peerDependenciesMeta": {
+        "napi-wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@parcel/rust-darwin-arm64": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.4.tgz",
+      "integrity": "sha512-P3Se36H9EO1fOlwXqQNQ+RsVKTGn5ztRSUGbLcT8ba6oOMmU1w7J4R810GgsCbwCuF10TJNUMkuD3Q2Sz15Q3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-darwin-x64": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.4.tgz",
+      "integrity": "sha512-8aNKNyPIx3EthYpmVJevIdHmFsOApXAEYGi3HU69jTxLgSIfyEHDdGE9lEsMvhSrd/SSo4/euAtiV+pqK04wnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-linux-arm-gnueabihf": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.4.tgz",
+      "integrity": "sha512-QrvqiSHaWRLc0JBHgUHVvDthfWSkA6AFN+ikV1UGENv4j2r/QgvuwJiG0VHrsL6pH5dRqj0vvngHzEgguke9DA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-linux-arm64-gnu": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.4.tgz",
+      "integrity": "sha512-f3gBWQHLHRUajNZi3SMmDQiEx54RoRbXtZYQNuBQy7+NolfFcgb1ik3QhkT7xovuTF/LBmaqP3UFy0PxvR/iwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-linux-arm64-musl": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.4.tgz",
+      "integrity": "sha512-cwml18RNKsBwHyZnrZg4jpecXkWjaY/mCArocWUxkFXjjB97L56QWQM9W86f2/Y3HcFcnIGJwx1SDDKJrV6OIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-linux-x64-gnu": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.4.tgz",
+      "integrity": "sha512-0xIjQaN8hiG0F9R8coPYidHslDIrbfOS/qFy5GJNbGA3S49h61wZRBMQqa7JFW4+2T8R0J9j0SKHhLXpbLXrIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-linux-x64-musl": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.4.tgz",
+      "integrity": "sha512-fYn21GIecHK9RoZPKwT9NOwxwl3Gy3RYPR6zvsUi0+hpFo19Ph9EzFXN3lT8Pi5KiwQMCU4rsLb5HoWOBM1FeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust-win32-x64-msvc": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.4.tgz",
+      "integrity": "sha512-TcpWC3I1mJpfP2++018lgvM7UX0P8IrzNxceBTHUKEIDMwmAYrUKAQFiaU0j1Ldqk6yP8SPZD3cvphumsYpJOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       },
       "funding": {
         "type": "opencollective",
@@ -1327,6 +1355,7 @@
       "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.1.tgz",
       "integrity": "sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -1335,23 +1364,24 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.12.0.tgz",
-      "integrity": "sha512-zQaBfOnf/l8rPxYGnsk/ufh/0EuqvmnxafjBIpKZ//j6rGylw5JCqXSb1QvvAqRYruKeccxGv7+HrxpqKU6V4A==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.16.4.tgz",
+      "integrity": "sha512-CMDUOQYX7+cmeyHxHSFnoPcwvXNL7rRFE+Q06uVFzsYYiVhbwGF/1J5Bx4cW3Froumqla4YTytTsEteJEybkdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.12.0",
-        "browserslist": "^4.6.6",
-        "json5": "^2.2.0",
+        "@parcel/utils": "2.16.4",
+        "browserslist": "^4.24.5",
+        "json5": "^2.2.3",
         "nullthrows": "^1.1.1",
-        "semver": "^7.5.2"
+        "semver": "^7.7.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1359,22 +1389,23 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.12.0.tgz",
-      "integrity": "sha512-vXhOqoAlQGATYyQ433Z1DXKmiKmzOAUmKysbYH3FD+LKEKLMEl/pA14goqp00TW+A/EjtSKKyeMyHlMIIUqj4Q==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.16.4.tgz",
+      "integrity": "sha512-VG/+DbDci2HKe20GFRDs65ZQf5GUFfnmZAa1BhVl/MO+ijT3XC3eoVUy5cExRkq4VLcPY4ytL0g/1T2D6x7lBQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.12.0",
-        "browserslist": "^4.6.6",
-        "lightningcss": "^1.22.1",
+        "@parcel/utils": "2.16.4",
+        "browserslist": "^4.24.5",
+        "lightningcss": "^1.30.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1382,24 +1413,19 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.12.0.tgz",
-      "integrity": "sha512-5jW4dFFBlYBvIQk4nrH62rfA/G/KzVzEDa6S+Nne0xXhglLjkm64Ci9b/d4tKZfuGWUbpm2ASAq8skti/nfpXw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.16.4.tgz",
+      "integrity": "sha512-w6JErYTeNS+KAzUAER18NHFIFFvxiLGd4Fht1UYcb/FDjJdLAMB/FljyEs0Rto/WAhZ2D0MuSL25HQh837R62g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5",
-        "posthtml-parser": "^0.10.1",
-        "posthtml-render": "^3.0.0",
-        "semver": "^7.5.2",
-        "srcset": "4"
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1407,66 +1433,87 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.12.0.tgz",
-      "integrity": "sha512-8hXrGm2IRII49R7lZ0RpmNk27EhcsH+uNKsvxuMpXPuEnWgC/ha/IrjaI29xCng1uGur74bJF43NUSQhR4aTdw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.16.4.tgz",
+      "integrity": "sha512-ZzIn3KvvRqMfcect4Dy+57C9XoQXZhpVJKBdQWMp9wM1qJEgsVgGDcaSBYCs/UYSKMRMP6Wm20pKCt408RkQzg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "@parcel/workers": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.12.0"
+        "@parcel/core": "^2.16.4"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.12.0.tgz",
-      "integrity": "sha512-OSZpOu+FGDbC/xivu24v092D9w6EGytB3vidwbdiJ2FaPgfV7rxS0WIUjH4I0OcvHAcitArRXL0a3+HrNTdQQw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.16.4.tgz",
+      "integrity": "sha512-FD2fdO6URwAGBPidb3x1dDgLBt972mko0LelcSU05aC/pcKaV9mbCtINbPul1MlStzkxDelhuImcCYIyerheVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0",
+        "@parcel/utils": "2.16.4",
+        "@parcel/workers": "2.16.4",
         "@swc/helpers": "^0.5.0",
-        "browserslist": "^4.6.6",
+        "browserslist": "^4.24.5",
         "nullthrows": "^1.1.1",
-        "regenerator-runtime": "^0.13.7",
-        "semver": "^7.5.2"
+        "regenerator-runtime": "^0.14.1",
+        "semver": "^7.7.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.12.0"
+        "@parcel/core": "^2.16.4"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.12.0.tgz",
-      "integrity": "sha512-Utv64GLRCQILK5r0KFs4o7I41ixMPllwOLOhkdjJKvf1hZmN6WqfOmB1YLbWS/y5Zb/iB52DU2pWZm96vLFQZQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.16.4.tgz",
+      "integrity": "sha512-pB3ZNqgokdkBCJ+4G0BrPYcIkyM9K1HVk0GvjzcLEFDKsoAp8BGEM68FzagFM/nVq9anYTshIaoh349GK0M/bg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "json5": "^2.2.0"
+        "@parcel/plugin": "2.16.4",
+        "json5": "^2.2.3"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-node": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-node/-/transformer-node-2.16.4.tgz",
+      "integrity": "sha512-7t43CPGfMJk1LqFokwxHSsRi+kKC2QvDXaMtqiMShmk50LCwn81WgzuFvNhMwf6lSiBihWupGwF3Fqksg+aisg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/plugin": "2.16.4"
+      },
+      "engines": {
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1474,23 +1521,24 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.12.0.tgz",
-      "integrity": "sha512-FZqn+oUtiLfPOn67EZxPpBkfdFiTnF4iwiXPqvst3XI8H+iC+yNgzmtJkunOOuylpYY6NOU5jT8d7saqWSDv2Q==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.16.4.tgz",
+      "integrity": "sha512-jfmh9ho03H+qwz9S1b/a/oaOmgfMovtHKYDweIGMjKULKIee3AFRqo8RZIOuUMjDuqHWK8SqQmjery4syFV3Xw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "clone": "^2.1.1",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "clone": "^2.1.2",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.2"
+        "semver": "^7.7.1"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1498,22 +1546,18 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.12.0.tgz",
-      "integrity": "sha512-z6Z7rav/pcaWdeD+2sDUcd0mmNZRUvtHaUGa50Y2mr+poxrKilpsnFMSiWBT+oOqPt7j71jzDvrdnAF4XkCljg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.16.4.tgz",
+      "integrity": "sha512-+GXsmGx1L25KQGQnwclgEuQe1t4QU+IoDkgN+Ikj+EnQCOWG4/ts2VpMBeqP5F18ZT4cCSRafj6317o/2lSGJg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5",
-        "posthtml-parser": "^0.10.1",
-        "posthtml-render": "^3.0.0",
-        "semver": "^7.5.2"
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1521,16 +1565,17 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.12.0.tgz",
-      "integrity": "sha512-Ht1fQvXxix0NncdnmnXZsa6hra20RXYh1VqhBYZLsDfkvGGFnXIgO03Jqn4Z8MkKoa0tiNbDhpKIeTjyclbBxQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.16.4.tgz",
+      "integrity": "sha512-7WDUPq+bW11G9jKxaQIVL+NPGolV99oq/GXhpjYip0SaGaLzRCW7gEk60cftuk0O7MsDaX5jcAJm3G/AX+LJKg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0"
+        "@parcel/plugin": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1538,18 +1583,20 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.12.0.tgz",
-      "integrity": "sha512-GE8gmP2AZtkpBIV5vSCVhewgOFRhqwdM5Q9jNPOY5PKcM3/Ff0qCqDiTzzGLhk0/VMBrdjssrfZkVx6S/lHdJw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.16.4.tgz",
+      "integrity": "sha512-MiLNZrsGQJTANKKa4lzZyUbGj/en0Hms474mMdQkCBFg6GmjfmXwaMMgtTfPA3ZwSp2+3LeObCyca/f9B2gBZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "react-refresh": "^0.9.0"
+        "@parcel/error-overlay": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "react-refresh": "^0.16.0"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1557,23 +1604,19 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.12.0.tgz",
-      "integrity": "sha512-cZJqGRJ4JNdYcb+vj94J7PdOuTnwyy45dM9xqbIMH+HSiiIkfrMsdEwYft0GTyFTdsnf+hdHn3tau7Qa5hhX+A==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.16.4.tgz",
+      "integrity": "sha512-0dm4cQr/WpfQP6N0xjFtwdLTxcONDfoLgTOMk4eNUWydHipSgmLtvUk/nOc/FWkwztRScfAObtZXOiPOd3Oy9A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5",
-        "posthtml-parser": "^0.10.1",
-        "posthtml-render": "^3.0.0",
-        "semver": "^7.5.2"
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/plugin": "2.16.4",
+        "@parcel/rust": "2.16.4"
       },
       "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
+        "node": ">= 16.0.0",
+        "parcel": "^2.16.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1581,37 +1624,47 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
-      "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.4.tgz",
+      "integrity": "sha512-ctx4mBskZHXeDVHg4OjMwx18jfYH9BzI/7yqbDQVGvd5lyA+/oVVzYdpele2J2i2sSaJ87cA8nb57GDQ8kHAqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/cache": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/package-manager": "2.12.0",
+        "@parcel/types-internal": "2.16.4",
+        "@parcel/workers": "2.16.4"
+      }
+    },
+    "node_modules/@parcel/types-internal": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.4.tgz",
+      "integrity": "sha512-PE6Qmt5cjzBxX+6MPLiF7r+twoC+V9Skt3zyuBQ+H1c0i9o07Bbz2NKX10nvlPukfmW6Fu/1RvTLkzBZR1bU6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/feature-flags": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/workers": "2.12.0",
-        "utility-types": "^3.10.0"
+        "utility-types": "^3.11.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
-      "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.4.tgz",
+      "integrity": "sha512-lkmxQHcHyOWZLbV8t+h2CGZIkPiBurLm/TS5wNT7+tq0qt9KbVwL7FP2K93TbXhLMGTmpI79Bf3qKniPM167Mw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/codeframe": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/markdown-ansi": "2.12.0",
-        "@parcel/rust": "2.12.0",
+        "@parcel/codeframe": "2.16.4",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/logger": "2.16.4",
+        "@parcel/markdown-ansi": "2.16.4",
+        "@parcel/rust": "2.16.4",
         "@parcel/source-map": "^2.1.1",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1619,15 +1672,17 @@
       }
     },
     "node_modules/@parcel/watcher": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.1.tgz",
-      "integrity": "sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
       "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "detect-libc": "^1.0.3",
+        "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
-        "micromatch": "^4.0.5",
-        "node-addon-api": "^7.0.0"
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -1637,28 +1692,30 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.4.1",
-        "@parcel/watcher-darwin-arm64": "2.4.1",
-        "@parcel/watcher-darwin-x64": "2.4.1",
-        "@parcel/watcher-freebsd-x64": "2.4.1",
-        "@parcel/watcher-linux-arm-glibc": "2.4.1",
-        "@parcel/watcher-linux-arm64-glibc": "2.4.1",
-        "@parcel/watcher-linux-arm64-musl": "2.4.1",
-        "@parcel/watcher-linux-x64-glibc": "2.4.1",
-        "@parcel/watcher-linux-x64-musl": "2.4.1",
-        "@parcel/watcher-win32-arm64": "2.4.1",
-        "@parcel/watcher-win32-ia32": "2.4.1",
-        "@parcel/watcher-win32-x64": "2.4.1"
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
       }
     },
     "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz",
-      "integrity": "sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -1672,13 +1729,14 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz",
-      "integrity": "sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1692,13 +1750,14 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz",
-      "integrity": "sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1712,13 +1771,14 @@
       }
     },
     "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz",
-      "integrity": "sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -1732,13 +1792,35 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz",
-      "integrity": "sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1752,13 +1834,14 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz",
-      "integrity": "sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1772,13 +1855,14 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.1.tgz",
-      "integrity": "sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1792,13 +1876,14 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.1.tgz",
-      "integrity": "sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1812,13 +1897,14 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.1.tgz",
-      "integrity": "sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1832,13 +1918,14 @@
       }
     },
     "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz",
-      "integrity": "sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1852,13 +1939,14 @@
       }
     },
     "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz",
-      "integrity": "sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1872,13 +1960,14 @@
       }
     },
     "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz",
-      "integrity": "sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1891,28 +1980,52 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/workers": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
-      "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
+    "node_modules/@parcel/watcher/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@parcel/workers": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.4.tgz",
+      "integrity": "sha512-dkBEWqnHXDZnRbTZouNt4uEGIslJT+V0c8OH1MPOfjISp1ucD6/u9ET8k9d/PxS9h1hL53og0SpBuuSEPLDl6A==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/profiler": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/logger": "2.16.4",
+        "@parcel/profiler": "2.16.4",
+        "@parcel/types-internal": "2.16.4",
+        "@parcel/utils": "2.16.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.12.0"
+        "@parcel/core": "^2.16.4"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1926,14 +2039,15 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-fjADAC5gOOX54Rpcr1lF9DHLD+nPD5H/zXLtEgK2Ez3esmogT+LfHzCZtUxqetjvaMChKhQ0Pp0ZB6Hpz/tCbw==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.11.tgz",
+      "integrity": "sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@swc/counter": "^0.1.2",
-        "@swc/types": "^0.1.5"
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.25"
       },
       "engines": {
         "node": ">=10"
@@ -1943,19 +2057,19 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.5.0",
-        "@swc/core-darwin-x64": "1.5.0",
-        "@swc/core-linux-arm-gnueabihf": "1.5.0",
-        "@swc/core-linux-arm64-gnu": "1.5.0",
-        "@swc/core-linux-arm64-musl": "1.5.0",
-        "@swc/core-linux-x64-gnu": "1.5.0",
-        "@swc/core-linux-x64-musl": "1.5.0",
-        "@swc/core-win32-arm64-msvc": "1.5.0",
-        "@swc/core-win32-ia32-msvc": "1.5.0",
-        "@swc/core-win32-x64-msvc": "1.5.0"
+        "@swc/core-darwin-arm64": "1.15.11",
+        "@swc/core-darwin-x64": "1.15.11",
+        "@swc/core-linux-arm-gnueabihf": "1.15.11",
+        "@swc/core-linux-arm64-gnu": "1.15.11",
+        "@swc/core-linux-arm64-musl": "1.15.11",
+        "@swc/core-linux-x64-gnu": "1.15.11",
+        "@swc/core-linux-x64-musl": "1.15.11",
+        "@swc/core-win32-arm64-msvc": "1.15.11",
+        "@swc/core-win32-ia32-msvc": "1.15.11",
+        "@swc/core-win32-x64-msvc": "1.15.11"
       },
       "peerDependencies": {
-        "@swc/helpers": "^0.5.0"
+        "@swc/helpers": ">=0.5.17"
       },
       "peerDependenciesMeta": {
         "@swc/helpers": {
@@ -1964,13 +2078,14 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.0.tgz",
-      "integrity": "sha512-dyA25zQjm3xmMFsRPFgBpSqWSW9TITnkndZkZAiPYLjBxH9oTNMa0l09BePsaqEeXySY++tUgAeYu/9onsHLbg==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.11.tgz",
+      "integrity": "sha512-QoIupRWVH8AF1TgxYyeA5nS18dtqMuxNwchjBIwJo3RdwLEFiJq6onOx9JAxHtuPwUkIVuU2Xbp+jCJ7Vzmgtg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1980,13 +2095,14 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.0.tgz",
-      "integrity": "sha512-cO7kZMMA/fcQIBT31LBzcVNSk3AZGVYLqvEPnJhFImjPm3mGKUd6kWpARUEGR68MyRU2VsWhE6eCjMcM+G7bxw==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.11.tgz",
+      "integrity": "sha512-S52Gu1QtPSfBYDiejlcfp9GlN+NjTZBRRNsz8PNwBgSE626/FUf2PcllVUix7jqkoMC+t0rS8t+2/aSWlMuQtA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1996,13 +2112,14 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.0.tgz",
-      "integrity": "sha512-BXaXytS4y9lBFRO6vwA6ovvy1d2ZIzS02i2R1oegoZzzNu89CJDpkYXYS9bId0GvK2m9Q9y2ofoZzKE2Rp3PqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.11.tgz",
+      "integrity": "sha512-lXJs8oXo6Z4yCpimpQ8vPeCjkgoHu5NoMvmJZ8qxDyU99KVdg6KwU9H79vzrmB+HfH+dCZ7JGMqMF//f8Cfvdg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -2012,13 +2129,14 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.0.tgz",
-      "integrity": "sha512-Bu4/41pGadXKnRsUbox0ig63xImATVH704oPCXcoOvNGkDyMjWgIAhzIi111vrwFNpj9utabgUE4AtlUa2tAOQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.11.tgz",
+      "integrity": "sha512-chRsz1K52/vj8Mfq/QOugVphlKPWlMh10V99qfH41hbGvwAU6xSPd681upO4bKiOr9+mRIZZW+EfJqY42ZzRyA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2028,13 +2146,14 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.0.tgz",
-      "integrity": "sha512-lUFFvC8tsepNcTnKEHNrePWanVVef6PQ82Rv9wIeebgGHRUqDh6+CyCqodXez+aKz6NyE/PBIfp0r+jPx4hoJA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.11.tgz",
+      "integrity": "sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2044,13 +2163,14 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.0.tgz",
-      "integrity": "sha512-c6LegFU1qdyMfk+GzNIOvrX61+mksm21Q01FBnXSy1nf1ACj/a86jmr3zkPl0zpNVHfPOw3Ry1QIuLQKD+67YA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.11.tgz",
+      "integrity": "sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2060,13 +2180,14 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.0.tgz",
-      "integrity": "sha512-I/V8aWBmfDWwjtM1bS8ASG+6PcO/pVFYyPP5g2ok46Vz1o1MnAUd18mHnWX43nqVJokaW+BD/G4ZMZ+gXRl4zQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.11.tgz",
+      "integrity": "sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2076,13 +2197,14 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.0.tgz",
-      "integrity": "sha512-nN685BvI7iM58xabrSOSQHUvIY10pcXh5H9DmS8LeYqG6Dkq7QZ8AwYqqonOitIS5C35MUfhSMLpOTzKoLdUqA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.11.tgz",
+      "integrity": "sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2092,13 +2214,14 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.0.tgz",
-      "integrity": "sha512-3YjltmEHljI+TvuDOC4lspUzjBUoB3X5BhftRBprSTJx/czuMl0vdoZKs2Snzb5Eqqesp0Rl8q+iQ1E1oJ6dEA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.11.tgz",
+      "integrity": "sha512-6XnzORkZCQzvTQ6cPrU7iaT9+i145oLwnin8JrfsLG41wl26+5cNQ2XV3zcbrnFEV6esjOceom9YO1w9mGJByw==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2108,13 +2231,14 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.0.tgz",
-      "integrity": "sha512-ZairtCwJsaxnUH85DcYCyGpNb9bUoIm9QXYW+VaEoXwbcB95dTIiJwN0aRxPT8B0B2MNw/CXLqjoPo6sDwz5iw==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.11.tgz",
+      "integrity": "sha512-IQ2n6af7XKLL6P1gIeZACskSxK8jWtoKpJWLZmdXTDj1MGzktUy4i+FvpdtxFmJWNavRWH1VmTr6kAubRDHeKw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2127,22 +2251,25 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
-      "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.6.tgz",
-      "integrity": "sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
+      "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
@@ -2187,28 +2314,20 @@
         "node": ">=4"
       }
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.13.0"
-      }
+    "node_modules/ag-charts-types": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-13.1.0.tgz",
+      "integrity": "sha512-DytRM3CXli+Y013SC1Mr8lQBrhVTACK+11ilDHOhwUM0sRpmGuR51XFGcBKOliW1Vas1AycP31Cm3Pp0jx3hqw==",
+      "license": "MIT"
     },
-    "node_modules/@types/pikaday": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@types/pikaday/-/pikaday-1.7.4.tgz",
-      "integrity": "sha512-0KsHVyw5pTG829nqG4IRu7m+BFQlFEBdbE/1i3S5182HeKUKv1uEW0gyEmkJVp5i4IV+9pyh23O83+KpRkSQbw==",
+    "node_modules/ag-grid-community": {
+      "version": "35.1.0",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-35.1.0.tgz",
+      "integrity": "sha512-yWFQfRNjv3KUBkHHzFdDOYGjPcDMU0B8Up4qG651diFlGRUGEGVs94SK73niWvk1FDZdpV9oWrwq3f30/qAoVg==",
+      "license": "MIT",
       "dependencies": {
-        "moment": ">=2.14.0"
+        "ag-charts-types": "13.1.0"
       }
-    },
-    "node_modules/abortcontroller-polyfill": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
-      "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==",
-      "dev": true
     },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
@@ -2262,12 +2381,6 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2275,10 +2388,11 @@
       "dev": true
     },
     "node_modules/base-x": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
-      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -2304,12 +2418,14 @@
       ],
       "license": "MIT"
     },
-    "node_modules/bignumber.js": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
-      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==",
-      "engines": {
-        "node": "*"
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
       }
     },
     "node_modules/binary-extensions": {
@@ -2324,17 +2440,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true
-    },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2352,9 +2463,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -2370,11 +2481,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2408,15 +2521,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -2427,9 +2531,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001612",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
-      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
+      "version": "1.0.30001770",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
+      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
       "dev": true,
       "funding": [
         {
@@ -2444,13 +2548,15 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2460,15 +2566,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chevrotain": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-6.5.0.tgz",
-      "integrity": "sha512-BwqQ/AgmKJ8jcMEjaSnfMybnKMgGTrtDKowfTP3pX4jwVy0kNjRsT/AP6h+wC3+3NC+X8X15VWBnTCQlX+wQFg==",
-      "optional": true,
-      "dependencies": {
-        "regexp-to-ast": "0.4.0"
       }
     },
     "node_modules/chokidar": {
@@ -2507,11 +2604,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chroma-js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.2.0.tgz",
+      "integrity": "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
     "node_modules/chrome-trace-event": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
-      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0"
       }
@@ -2521,6 +2625,7 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -2544,48 +2649,13 @@
       "dev": true
     },
     "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/core-js": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
-      "integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-      "dev": true,
-      "dependencies": {
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "node": ">=18"
       }
     },
     "node_modules/cross-spawn": {
@@ -2603,114 +2673,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-select/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/css-select/node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/css-select/node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/css-select/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2723,45 +2685,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/csso": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "css-tree": "~2.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/css-tree": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mdn-data": "2.0.28",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/mdn-data": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/dayjs": {
       "version": "1.11.10",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
@@ -2772,6 +2695,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -2791,90 +2715,34 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
     },
-    "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ]
-    },
-    "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
-    },
-    "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
     "node_modules/dotenv": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
-      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
-      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
-      "dev": true
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2899,10 +2767,11 @@
       "license": "0BSD"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.748",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.748.tgz",
-      "integrity": "sha512-VWqjOlPZn70UZ8FTKUOkUvBLeTQ0xpty66qV0yJcAGY2/CthI4xyW9aEozRVtuwv3Kpf5xTesmJUcPwuJmgP4A==",
-      "dev": true
+      "version": "1.5.286",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -2910,43 +2779,14 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
-    "node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/fast-glob": {
@@ -3047,10 +2887,12 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -3083,6 +2925,7 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -3093,29 +2936,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/handsontable": {
-      "version": "14.6.2",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-14.6.2.tgz",
-      "integrity": "sha512-APFGejWTnADsZHZdlSQAireaFip80Cw+Doj2Z6bzsbawy7F0IwcPaLD5gv2T7F0oG+f4Q2yjWZcrufBXlm1SiQ==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "dependencies": {
-        "@handsontable/pikaday": "^1.0.0",
-        "@types/pikaday": "1.7.4",
-        "core-js": "^3.37.0",
-        "dompurify": "^2.1.1",
-        "moment": "2.30.1",
-        "numbro": "2.1.2",
-        "pikaday": "1.8.2"
-      },
-      "optionalDependencies": {
-        "hyperformula": "^2.6.2"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3130,82 +2956,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/htmlnano": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.1.0.tgz",
-      "integrity": "sha512-jVGRE0Ep9byMBKEu0Vxgl8dhXYOUk0iNQ2pjsG+BcRB0u0oDF5A9p/iBGMg/PGKYUyMD0OAGu8dVT5Lzj8S58g==",
-      "dev": true,
-      "dependencies": {
-        "cosmiconfig": "^8.0.0",
-        "posthtml": "^0.16.5",
-        "timsort": "^0.3.0"
-      },
-      "peerDependencies": {
-        "cssnano": "^6.0.0",
-        "postcss": "^8.3.11",
-        "purgecss": "^5.0.0",
-        "relateurl": "^0.2.7",
-        "srcset": "4.0.0",
-        "svgo": "^3.0.2",
-        "terser": "^5.10.0",
-        "uncss": "^0.17.3"
-      },
-      "peerDependenciesMeta": {
-        "cssnano": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "purgecss": {
-          "optional": true
-        },
-        "relateurl": {
-          "optional": true
-        },
-        "srcset": {
-          "optional": true
-        },
-        "svgo": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "uncss": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.2",
-        "domutils": "^2.8.0",
-        "entities": "^3.0.1"
-      }
-    },
-    "node_modules/hyperformula": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-2.7.0.tgz",
-      "integrity": "sha512-fbpLfT8tDGKVA8tIAw4yJ9neQXabL9zJQ3T2de1r7RbdcneGQ9B6hRzi57SFfQ9vy76iR4JexEYG/pV6mcsW8Q==",
-      "optional": true,
-      "dependencies": {
-        "chevrotain": "^6.5.0",
-        "tiny-emitter": "^2.1.0"
       }
     },
     "node_modules/ieee754": {
@@ -3228,28 +2978,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -3308,12 +3036,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-json": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
-      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
-      "dev": true
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3353,35 +3075,12 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -3390,12 +3089,13 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.24.1.tgz",
-      "integrity": "sha512-kUpHOLiH5GB0ERSv4pxqlL0RYKnOXtgGtVe7shDGfhS0AZ4D1ouKFYAcLcZhql8aMspDNzaUCumGHZ78tb2fTg==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
+      "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
-        "detect-libc": "^1.0.3"
+        "detect-libc": "^2.0.3"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -3405,25 +3105,49 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.24.1",
-        "lightningcss-darwin-x64": "1.24.1",
-        "lightningcss-freebsd-x64": "1.24.1",
-        "lightningcss-linux-arm-gnueabihf": "1.24.1",
-        "lightningcss-linux-arm64-gnu": "1.24.1",
-        "lightningcss-linux-arm64-musl": "1.24.1",
-        "lightningcss-linux-x64-gnu": "1.24.1",
-        "lightningcss-linux-x64-musl": "1.24.1",
-        "lightningcss-win32-x64-msvc": "1.24.1"
+        "lightningcss-android-arm64": "1.31.1",
+        "lightningcss-darwin-arm64": "1.31.1",
+        "lightningcss-darwin-x64": "1.31.1",
+        "lightningcss-freebsd-x64": "1.31.1",
+        "lightningcss-linux-arm-gnueabihf": "1.31.1",
+        "lightningcss-linux-arm64-gnu": "1.31.1",
+        "lightningcss-linux-arm64-musl": "1.31.1",
+        "lightningcss-linux-x64-gnu": "1.31.1",
+        "lightningcss-linux-x64-musl": "1.31.1",
+        "lightningcss-win32-arm64-msvc": "1.31.1",
+        "lightningcss-win32-x64-msvc": "1.31.1"
       }
     },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.24.1.tgz",
-      "integrity": "sha512-1jQ12jBy+AE/73uGQWGSafK5GoWgmSiIQOGhSEXiFJSZxzV+OXIx+a9h2EYHxdJfX864M+2TAxWPWb0Vv+8y4w==",
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz",
+      "integrity": "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz",
+      "integrity": "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -3437,13 +3161,14 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.24.1.tgz",
-      "integrity": "sha512-R4R1d7VVdq2mG4igMU+Di8GPf0b64ZLnYVkubYnGG0Qxq1KaXQtAzcLI43EkpnoWvB/kUg8JKCWH4S13NfiLcQ==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz",
+      "integrity": "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -3457,13 +3182,14 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.24.1.tgz",
-      "integrity": "sha512-z6NberUUw5ALES6Ixn2shmjRRrM1cmEn1ZQPiM5IrZ6xHHL5a1lPin9pRv+w6eWfcrEo+qGG6R9XfJrpuY3e4g==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz",
+      "integrity": "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
@@ -3477,13 +3203,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.24.1.tgz",
-      "integrity": "sha512-NLQLnBQW/0sSg74qLNI8F8QKQXkNg4/ukSTa+XhtkO7v3BnK19TS1MfCbDHt+TTdSgNEBv0tubRuapcKho2EWw==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz",
+      "integrity": "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3497,13 +3224,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.24.1.tgz",
-      "integrity": "sha512-AQxWU8c9E9JAjAi4Qw9CvX2tDIPjgzCTrZCSXKELfs4mCwzxRkHh2RCxX8sFK19RyJoJAjA/Kw8+LMNRHS5qEg==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz",
+      "integrity": "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3517,13 +3245,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.24.1.tgz",
-      "integrity": "sha512-JCgH/SrNrhqsguUA0uJUM1PvN5+dVuzPIlXcoWDHSv2OU/BWlj2dUYr3XNzEw748SmNZPfl2NjQrAdzaPOn1lA==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz",
+      "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3537,13 +3266,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.24.1.tgz",
-      "integrity": "sha512-TYdEsC63bHV0h47aNRGN3RiK7aIeco3/keN4NkoSQ5T8xk09KHuBdySltWAvKLgT8JvR+ayzq8ZHnL1wKWY0rw==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
+      "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3557,13 +3287,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.24.1.tgz",
-      "integrity": "sha512-HLfzVik3RToot6pQ2Rgc3JhfZkGi01hFetHt40HrUMoeKitLoqUUT5owM6yTZPTytTUW9ukLBJ1pc3XNMSvlLw==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz",
+      "integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3576,14 +3307,15 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.24.1.tgz",
-      "integrity": "sha512-joEupPjYJ7PjZtDsS5lzALtlAudAbgIBMGJPNeFe5HfdmJXFd13ECmEM+5rXNxYVMRHua2w8132R6ab5Z6K9Ow==",
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz",
+      "integrity": "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -3594,6 +3326,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz",
+      "integrity": "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lilconfig": {
@@ -3617,6 +3380,7 @@
       "integrity": "sha512-9bMdFfc80S+vSldBmG3HOuLVHnxRdNTlpzR6QDnzqCQtCzGUEAGTzBKYMeIM+I/sU4oZfgbcbS7X7F65/z/oxQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "msgpackr": "^1.9.5",
         "node-addon-api": "^6.1.0",
@@ -3640,7 +3404,8 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",
@@ -3659,26 +3424,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3735,52 +3480,60 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/msgpackr": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
-      "integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.8.tgz",
+      "integrity": "sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA==",
       "dev": true,
+      "license": "MIT",
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
-      "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "node-gyp-build-optional-packages": "5.0.7"
+        "node-gyp-build-optional-packages": "5.2.2"
       },
       "bin": {
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/msgpackr-extract/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/msgpackr-extract/node_modules/node-gyp-build-optional-packages": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
-      "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
       "bin": {
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
@@ -3818,19 +3571,18 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
-      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
-      "engines": {
-        "node": "^16 || ^18 || >= 20"
-      }
+      "license": "MIT"
     },
     "node_modules/node-gyp-build-optional-packages": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
       "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.1"
       },
@@ -3841,19 +3593,21 @@
       }
     },
     "node_modules/node-gyp-build-optional-packages/node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-      "dev": true
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3864,34 +3618,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
     "node_modules/nullthrows": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
-      "dev": true
-    },
-    "node_modules/numbro": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.1.2.tgz",
-      "integrity": "sha512-7w833BxZmKGLE9HI0aREtNVRVH6WTYUUlWf4qgA5gKNhPQ4F/MRZ14sc0v8eoLORprk9ZTVwYaLwj8N3Zgxwiw==",
-      "dependencies": {
-        "bignumber.js": "^8.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3912,10 +3644,11 @@
       }
     },
     "node_modules/ordered-binary": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.1.tgz",
-      "integrity": "sha512-5VyHfHY3cd0iza71JepYG50My+YUbrFtGoUz2ooEydPyPM7Aai/JW098juLr+RG6+rDJuzNNTsEQu2DZa1A41A==",
-      "dev": true
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.6.1.tgz",
+      "integrity": "sha512-QkCdPooczexPLiXIrbVOPYkR3VO3T6v2OyKRkR1Xbhpy7/LAVXwahnRCgRp78Oe/Ehf0C/HATAxfSr6eA1oX+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.0",
@@ -3924,65 +3657,37 @@
       "dev": true
     },
     "node_modules/parcel": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.12.0.tgz",
-      "integrity": "sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.16.4.tgz",
+      "integrity": "sha512-RQlrqs4ujYNJpTQi+dITqPKNhRWEqpjPd1YBcGp50Wy3FcJHpwu0/iRm7XWz2dKU/Bwp2qCcVYPIeEDYi2uOUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@parcel/config-default": "2.12.0",
-        "@parcel/core": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/package-manager": "2.12.0",
-        "@parcel/reporter-cli": "2.12.0",
-        "@parcel/reporter-dev-server": "2.12.0",
-        "@parcel/reporter-tracer": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "chalk": "^4.1.0",
-        "commander": "^7.0.0",
+        "@parcel/config-default": "2.16.4",
+        "@parcel/core": "2.16.4",
+        "@parcel/diagnostic": "2.16.4",
+        "@parcel/events": "2.16.4",
+        "@parcel/feature-flags": "2.16.4",
+        "@parcel/fs": "2.16.4",
+        "@parcel/logger": "2.16.4",
+        "@parcel/package-manager": "2.16.4",
+        "@parcel/reporter-cli": "2.16.4",
+        "@parcel/reporter-dev-server": "2.16.4",
+        "@parcel/reporter-tracer": "2.16.4",
+        "@parcel/utils": "2.16.4",
+        "chalk": "^4.1.2",
+        "commander": "^12.1.0",
         "get-port": "^4.2.0"
       },
       "bin": {
         "parcel": "lib/bin.js"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-key": {
@@ -4022,20 +3727,12 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4057,11 +3754,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/pikaday": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/pikaday/-/pikaday-1.8.2.tgz",
-      "integrity": "sha512-TNtsE+34BIax3WtkB/qqu5uepV1McKYEgvL3kWzU7aqPCpMEN6rBF3AOwu4WCwAealWlBGobXny/9kJb49C1ew=="
     },
     "node_modules/pirates": {
       "version": "4.0.6",
@@ -4227,55 +3919,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/posthtml": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
-      "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
-      "dev": true,
-      "dependencies": {
-        "posthtml-parser": "^0.11.0",
-        "posthtml-render": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/posthtml-parser": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.2.tgz",
-      "integrity": "sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==",
-      "dev": true,
-      "dependencies": {
-        "htmlparser2": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/posthtml-render": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-      "dev": true,
-      "dependencies": {
-        "is-json": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/posthtml/node_modules/posthtml-parser": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
-      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
-      "dev": true,
-      "dependencies": {
-        "htmlparser2": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4296,17 +3939,12 @@
         }
       ]
     },
-    "node_modules/react-error-overlay": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
-      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
-      "dev": true
-    },
     "node_modules/react-refresh": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
-      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.16.0.tgz",
+      "integrity": "sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4333,16 +3971,11 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
-    },
-    "node_modules/regexp-to-ast": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.4.0.tgz",
-      "integrity": "sha512-4qf/7IsIKfSNHQXSwial1IFmfM1Cc/whNBQqRwe0V2stPe7KmN1U0tWQiIx6JiirgSrisjE0eECdNf7Tav1Ntw==",
-      "optional": true
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -4359,15 +3992,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/reusify": {
@@ -4421,16 +4045,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4471,15 +4094,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
@@ -4488,25 +4102,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/srcset": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
-      "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
-      "dev": true
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -4640,6 +4235,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4657,33 +4253,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/svgo": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
-      "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^2.3.1",
-        "css-what": "^6.1.0",
-        "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
       }
     },
     "node_modules/tailwindcss": {
@@ -4728,6 +4297,7 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
       "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -4756,18 +4326,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/timsort": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
-      "dev": true
-    },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4787,16 +4345,18 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -4817,9 +4377,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -4835,9 +4395,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -4857,6 +4418,7 @@
       "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
       "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -4865,7 +4427,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -4969,12 +4532,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/yaml": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "tailwindcss": "^3.4.11"
   },
   "dependencies": {
+    "ag-grid-community": "^35.1.0",
+    "chroma-js": "^3.2.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.5.1",
-    "handsontable": "^14.3.0",
     "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
Handsontable v14 uses a proprietary commercial license ($900+/yr), making it the sole blocker for MIT license compliance. This commit replaces it with AG Grid Community v35 (MIT) across all 5 table instances.

New files:
- js/ag-grid-wrapper.ts: Wrapper module (~360 lines) encapsulating AG Grid specifics — createXmritGrid() factory, XmritGrid interface, ClickableHeader component, custom context menu, spare row logic, and extendDateSeries() helper.

Preserved functionality:
- Cell editing (click-to-edit, tab navigation) — native AG Grid
- Context menu (insert row above/below, remove row) — custom implementation
- Undo/Redo (Ctrl+Z/Y and context menu) — AG Grid UndoRedoEditModule
- Auto spare row at bottom (minSpareRows) — custom post-edit check
- Date validation — dayjs strict parsing (YYYY-MM-DD) via valueSetter
- Numeric coercion (strip non-numeric chars) — via valueParser
- Editable column headers (click to rename) — ClickableHeader component
- Duplicate date detection (yellow highlight) — cellClassRules + Set
- Seasonal coloring (white-to-blue gradient) — cellStyle callbacks
- Row number column on seasonal factors table — valueGetter column
- Auto-height tables — domLayout: 'autoHeight'
- Stretch columns to fill width — defaultColDef: { flex: 1 }
- Paste from clipboard — AG Grid native. Handsontable's repeat-data quirk (which required the beforePasteTable workaround) does not exist in AG Grid, so the workaround was removed.
- Chart updates on data edit — syncGridToState() on every change
- Share link encoding/decoding — unchanged
- CSV download — unchanged

Changed functionality:
- Fill handle (drag-to-extend dates) replaced by "Extend dates" button on each table. Uses the same date-pattern-detection algorithm (rewritten with dayjsi nstead of native Date). More discoverable but no longer drag-based.
- Date validation now uses strict mode (dayjs with format string), rejecting impossible dates like "2020-45-23" that the old lenient parsing silently accepted.
- Compact Alpine theme (fontSize: 12, spacing: 3) to approximate the denser Handsontable row height.

Not preserved (AG Grid Community limitations):
- Range selection (multi-cell select) — Enterprise only. Single-cell Ctrl+C copy still works natively.
- Context menu Copy/Cut actions — removed because clipboard API requires direct user gesture, which menu clicks don't satisfy. Keyboard shortcuts (Ctrl+C/X) still work.

Other changes:
- Renamed grid variables: hot→grid, trendHot→trendGrid, etc.
- Removed ~60 transitive dependencies (hyperformula, moment, core-js, numbro, dompurify, pikaday, etc.)
- Added customParseFormat dayjs plugin for strict date parsing
- Updated CSS: .handsontable→.ag-theme-alpine selectors, added context menu and separator styles
- Removed Handsontable CDN CSS link from index.html (AG Grid v35 injects theme CSS via JS)