### PR TITLE
Improve v0 share link UTF-8 decoding and fix dev setup

### DIFF
--- a/js/main3.ts
+++ b/js/main3.ts
@@ -3390,7 +3390,7 @@ async function decodeShareLink(
     d = decodeURIComponent(d);
     dividers = decodeURIComponent(dividers);
     let [datePart, valuePart] = d.split(".", 2);
-    let dateText = lz77.decompress(atobUrlSafe(datePart));
+    let dateText = binaryStringToUtf8(lz77.decompress(atobUrlSafe(datePart)));
     let values = decodeNumberArrayString(valuePart);
     // hack[1]: reverse the , -> ; encoding
     let dates = dateText.split(",").map((d) => d.replace(";", ","));
@@ -3546,6 +3546,13 @@ function round(n: number, decimal_point: number = DECIMAL_POINT): number {
 
 function atobUrlSafe(s: string) {
   return atob(s.replace(/-/g, "+").replace(/_/g, "/"));
+}
+
+/** Decode a binary string (each char = byte 0–255) as UTF-8. LZ77 decompress returns raw bytes; labels are UTF-8. */
+function binaryStringToUtf8(binaryStr: string): string {
+  const bytes = new Uint8Array(binaryStr.length);
+  for (let i = 0; i < binaryStr.length; i++) bytes[i] = binaryStr.charCodeAt(i);
+  return new TextDecoder("utf-8").decode(bytes);
 }
 
 function btoaUrlSafe(s: string) {


### PR DESCRIPTION
This PR improves how v0 share links decode date/label text (UTF-8) and fixes two issues so `npm run start` works reliably.

AI (Cursor) has been used in creating this PR. 

### 1. Refactor date decoding in share link processing (main change)
**Problem**: When decoding v0 share links, the decompressed date/label payload was used as a raw string. The v0 spec stores that payload as UTF-8 bytes (e.g. for labels and dates with non-ASCII characters). Treating it as a plain string can mis-handle or corrupt non-ASCII content.

**Change**: Decode the decompressed blob as UTF-8 before parsing:
Add a small helper binaryStringToUtf8() that treats a binary string (one byte per character) as UTF-8 and decodes it with TextDecoder("utf-8").

In v0 decode, pass the LZ77 decompressed date part through binaryStringToUtf8() before splitting and parsing labels/dates.

**Files**: js/main3.ts (new helper + one call site in decodeShareLink).

**Result**: v0 share links with UTF-8 in axis labels or date strings decode correctly.

### 2. Dev setup fixes
This has been fixed in upstream main. 

#### ~~Start script – create dist before copy~~
~~`npm run start` runs `cp xmrit-bg.png dist/` before Parcel has created dist/, so the copy can fail with “No such file or directory”.
Fix: Run `mkdir -p dist` before the copy so dist exists.~~

#### ~~Add missing chroma-js dependency~~
~~js/main3.ts imports chroma-js but it was not in package.json, causing the build to fail with “Cannot find module 'chroma-js'”.
Fix: Add and install chroma-js so the project builds.
Files: package.json, package-lock.json.~~