### PR TITLE
Improve limit line tooltips to show line labels alongside values

### DIFF
--- a/js/main3.ts
+++ b/js/main3.ts
@@ -936,11 +936,13 @@ function renderLimitLines(stats: _Stats) {
       name,
       lineStyle,
       statisticY,
+      tooltipLabel,
       showLabel = false,
     }: {
       name: string;
       lineStyle: any;
       statisticY: number;
+      tooltipLabel: string;
       showLabel?: boolean;
     }) => ({
       name: name,
@@ -950,7 +952,7 @@ function renderLimitLines(stats: _Stats) {
         lineStyle,
         tooltip: {
           show: true,
-          formatter: `${statisticY}`,
+          formatter: `${tooltipLabel}: ${statisticY}`,
           textStyle: {
             fontWeight: "bold",
           },
@@ -991,6 +993,7 @@ function renderLimitLines(stats: _Stats) {
           type: lineType,
         },
         statisticY: lv.avgMovement ?? 0,
+        tooltipLabel: "Avg Movement",
         showLabel: isLastSegment,
       }),
       createHorizontalLimitLineSeries({
@@ -1001,6 +1004,7 @@ function renderLimitLines(stats: _Stats) {
           type: lineType,
         },
         statisticY: lv.URL ?? 0,
+        tooltipLabel: "Upper Movement Limit",
         showLabel: isLastSegment,
       }),
     ]);
@@ -1025,6 +1029,7 @@ function renderLimitLines(stats: _Stats) {
           width: 1,
         },
         statisticY: lv.lowerQuartile ?? 0,
+        tooltipLabel: "Lower Halfway",
       }),
       options.useUpperQuartile &&
       createHorizontalLimitLineSeries({
@@ -1036,6 +1041,7 @@ function renderLimitLines(stats: _Stats) {
           width: 1,
         },
         statisticY: lv.upperQuartile ?? 0,
+        tooltipLabel: "Upper Halfway",
       }),
       createHorizontalLimitLineSeries({
         name: `${i}-avg`,
@@ -1045,6 +1051,7 @@ function renderLimitLines(stats: _Stats) {
           type: lineType,
         },
         statisticY: lv.avgX ?? 0,
+        tooltipLabel: "Avg X",
         showLabel: isLastSegment,
       }),
       createHorizontalLimitLineSeries({
@@ -1055,6 +1062,7 @@ function renderLimitLines(stats: _Stats) {
           type: lineType,
         },
         statisticY: lv.UNPL ?? 0,
+        tooltipLabel: "Upper X limit (UNPL)",
         showLabel: isLastSegment,
       }),
       createHorizontalLimitLineSeries({
@@ -1065,6 +1073,7 @@ function renderLimitLines(stats: _Stats) {
           type: lineType,
         },
         statisticY: lv.LNPL ?? 0,
+        tooltipLabel: "Lower X limit (LNPL)",
         showLabel: isLastSegment,
       }),
     ]);


### PR DESCRIPTION
This PR changes tooltips on limit lines to show the line name alongside the value (e.g. "Upper X limit (UNPL): 98670.6" instead of just "98670.6"), making it easier to identify lines. Applies to all lines in both the X chart (UNPL, LNPL, Avg X, Upper/Lower Halfway) and MR chart (Upper Movement Limit, Avg Movement).

<img width="506" height="235" alt="image" src="https://github.com/user-attachments/assets/77905d79-e0c3-48f9-81ac-b73142560bfe" />
